### PR TITLE
Add intra pred unit test

### DIFF
--- a/test/api_test/CMakeLists.txt
+++ b/test/api_test/CMakeLists.txt
@@ -37,6 +37,12 @@ file(GLOB all_files
     "*.h"
     "*.cc")
 
+if(BUILD_SHARED_LIBS)
+    set (SvtAv1EncLib SvtAv1EncShared)
+else()
+    set (SvtAv1EncLib SvtAv1EncStatic)
+endif()
+
 if (UNIX)
         
   # App Source Files
@@ -45,7 +51,7 @@ if (UNIX)
 
     # Link the Encoder App
      target_link_libraries (SvtAv1ApiTests
-        SvtAv1Enc
+        ${SvtAv1EncLib}
         gtest_all 
         pthread
         m)

--- a/test/e2e_test/CMakeLists.txt
+++ b/test/e2e_test/CMakeLists.txt
@@ -17,13 +17,11 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/Bin/${CMAKE_BUILD_TYPE}
 include_directories (${PROJECT_SOURCE_DIR}/test/)
 include_directories (${PROJECT_SOURCE_DIR}/Bin/${CMAKE_BUILD_TYPE}/)
 include_directories(${PROJECT_SOURCE_DIR}/third_party/googletest/include third_party/googletest/src)
-include_directories(${PROJECT_SOURCE_DIR}/third_party/SDL2-2.0.9/include)
 include_directories(${PROJECT_SOURCE_DIR}/third_party/aom/inc)
 include_directories(${PROJECT_SOURCE_DIR}/Source/API)
 
 # Link Subdirectories
 if (MSVC OR MSYS OR MINGW OR WIN32)
-link_directories(${PROJECT_SOURCE_DIR}/third_party/SDL2-2.0.9/lib/x64)
 link_directories(${PROJECT_SOURCE_DIR}/third_party/aom/lib/msvc)
 endif(MSVC OR MSYS OR MINGW OR WIN32)
 if (UNIX AND NOT APPLE)
@@ -60,6 +58,12 @@ file(GLOB all_files
     "../../Source/App/EncApp/EbAppInputy4m.c"
     "../../Source/App/EncApp/EbAppString.c")
 
+if(BUILD_SHARED_LIBS)
+    set (SvtAv1EncLib SvtAv1EncShared)
+else()
+    set (SvtAv1EncLib SvtAv1EncStatic)
+endif()
+
 if (UNIX)
         
   # App Source Files
@@ -80,7 +84,7 @@ if (UNIX)
     # Link the Encoder App
      target_link_libraries (SvtAv1E2ETests
         aom
-        SvtAv1Enc
+        ${SvtAv1EncLib}
         gtest_all 
         pthread
         m)
@@ -89,7 +93,7 @@ endif(UNIX)
 
 if (MSVC OR MSYS OR MINGW OR WIN32)
 
-    set (lib_list SvtAv1Enc gtest_all)
+    set (lib_list ${SvtAv1EncLib} gtest_all)
                         
     cxx_executable_with_flags(SvtAv1E2ETests "${cxx_default}"
       "${lib_list}" ${all_files})

--- a/test/intrapred_cfl_test.cc
+++ b/test/intrapred_cfl_test.cc
@@ -1,0 +1,169 @@
+/*
+ * Copyright(c) 2019 Netflix, Inc.
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+/******************************************************************************
+ * @file intrapred_edge_filter_test.cc
+ *
+ * @brief Unit test for chroma from luma prediction:
+ * - cfl_predict_hbd_avx2
+ * - cfl_predict_lbd_avx2
+ *
+ * @author Cidana-Wenyao
+ *
+ ******************************************************************************/
+
+#include "gtest/gtest.h"
+#include "aom_dsp_rtcd.h"
+#include "EbDefinitions.h"
+#include "random.h"
+namespace {
+using svt_av1_test_tool::SVTRandom;
+
+using CFL_PRED_HBD = void (*)(const int16_t *pred_buf_q3, uint16_t *pred,
+                              int32_t pred_stride, uint16_t *dst,
+                              int32_t dst_stride, int32_t alpha_q3,
+                              int32_t bit_depth, int32_t width, int32_t height);
+using CFL_PRED_LBD = void (*)(const int16_t *pred_buf_q3, uint8_t *pred,
+                              int32_t pred_stride, uint8_t *dst,
+                              int32_t dst_stride, int32_t alpha_q3,
+                              int32_t bit_depth, int32_t width, int32_t height);
+/**
+ * @brief Unit test for chroma from luma prediction:
+ * - cfl_predict_hbd_avx2
+ * - cfl_predict_lbd_avx2
+ *
+ * Test strategy:
+ * Verify this assembly code by comparing with reference c implementation.
+ * Feed the same data and check test output and reference output.
+ * Define a templete class to handle the common process, and
+ * declare sub class to handle different bitdepth and function types.
+ *
+ * Expect result:
+ * Output from assemble functions should be the same with output from c.
+ *
+ * Test coverage:
+ * Test cases:
+ * pred buffer and dst buffer: Fill with random values
+ * TxSize: all the TxSize.
+ * alpha_q3: [-16, 16]
+ * BitDepth: 8bit and 10bit
+ */
+template <typename Pixel, typename FuncType>
+class CflPredTest {
+  public:
+    CflPredTest() {
+        bd_ = 8;
+        ref_func_ = nullptr;
+        tst_func_ = nullptr;
+        common_init();
+    }
+
+    virtual ~CflPredTest() {
+    }
+
+    void RunAllTest() {
+        // for pred_buf, after sampling and subtracted from average
+        SVTRandom pred_rnd(bd_ + 3 + 1, true);
+        SVTRandom dst_rnd(4, false);
+        for (int tx = TX_4X4; tx < TX_SIZES_ALL; ++tx) {
+            const int c_w = tx_size_wide[tx] >> 1;
+            const int c_h = tx_size_high[tx] >> 1;
+            const int c_stride = CFL_BUF_LINE;
+            memset(pred_buf_q3, 0, sizeof(pred_buf_q3));
+            memset(dst_buf_ref_data_, 0, sizeof(dst_buf_ref_data_));
+            memset(dst_buf_tst_data_, 0, sizeof(dst_buf_tst_data_));
+
+            for (int alpha_q3 = -16; alpha_q3 <= 16; ++alpha_q3) {
+                // prepare data
+                for (int y = 0; y < c_h; ++y) {
+                    for (int x = 0; x < c_w; ++x) {
+                        pred_buf_q3[y * c_stride + x] = pred_rnd.random();
+                        dst_buf_ref_[y * c_stride + x] =
+                            dst_buf_tst_[y * c_stride + x] = dst_rnd.random();
+                    }
+                }
+
+                ref_func_(pred_buf_q3,
+                          dst_buf_ref_,
+                          CFL_BUF_LINE,
+                          dst_buf_ref_,
+                          CFL_BUF_LINE,
+                          alpha_q3,
+                          bd_,
+                          c_w,
+                          c_h);
+                tst_func_(pred_buf_q3,
+                          dst_buf_tst_,
+                          c_stride,
+                          dst_buf_tst_,
+                          c_stride,
+                          alpha_q3,
+                          bd_,
+                          c_w,
+                          c_h);
+
+                for (int y = 0; y < c_h; ++y) {
+                    for (int x = 0; x < c_w; ++x) {
+                        ASSERT_EQ(dst_buf_ref_[y * c_stride + x],
+                                  dst_buf_tst_[y * c_stride + x])
+                            << "tx_size: " << tx << " alpha_q3 " << alpha_q3
+                            << " expect " << dst_buf_ref_[y * c_stride + x]
+                            << " got " << dst_buf_tst_[y * c_stride + x]
+                            << " at [ " << x << " x " << y << " ]";
+                    }
+                }
+            }
+        }
+    }
+
+  protected:
+    void common_init() {
+        dst_buf_ref_ = reinterpret_cast<Pixel *>(
+            ((intptr_t)(dst_buf_ref_data_) + alignment - 1) & ~(alignment - 1));
+        dst_buf_tst_ = reinterpret_cast<Pixel *>(
+            ((intptr_t)(dst_buf_tst_data_) + alignment - 1) & ~(alignment - 1));
+    }
+
+    static const int alignment = 32;
+    int16_t pred_buf_q3[CFL_BUF_SQUARE];
+    Pixel dst_buf_ref_data_[CFL_BUF_SQUARE + alignment - 1];
+    Pixel dst_buf_tst_data_[CFL_BUF_SQUARE + alignment - 1];
+    Pixel *dst_buf_ref_;
+    Pixel *dst_buf_tst_;
+    FuncType ref_func_;
+    FuncType tst_func_;
+    int bd_;
+};
+
+class LbdCflPredTest : public CflPredTest<uint8_t, CFL_PRED_LBD> {
+  public:
+    LbdCflPredTest() {
+        bd_ = 8;
+        ref_func_ = cfl_predict_lbd_c;
+        tst_func_ = cfl_predict_lbd_avx2;
+        common_init();
+    }
+};
+
+class HbdCflPredTest : public CflPredTest<uint16_t, CFL_PRED_HBD> {
+  public:
+    HbdCflPredTest() {
+        bd_ = 10;
+        ref_func_ = cfl_predict_hbd_c;
+        tst_func_ = cfl_predict_hbd_avx2;
+        common_init();
+    }
+};
+
+#define TEST_CLASS(tc_name, type_name)     \
+    TEST(tc_name, match_test) {            \
+        type_name *test = new type_name(); \
+        test->RunAllTest();                \
+        delete test;                       \
+    }
+
+TEST_CLASS(LbdCflPredMatchTest, LbdCflPredTest)
+TEST_CLASS(HbdCflPredMatchTest, HbdCflPredTest)
+}  // namespace

--- a/test/intrapred_dr_test.cc
+++ b/test/intrapred_dr_test.cc
@@ -1,0 +1,487 @@
+/*
+ * Copyright(c) 2019 Netflix, Inc.
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+/******************************************************************************
+ * @file intrapred_dr_test.cc
+ *
+ * @brief Unit test for intra directional prediction :
+ * - av1_highbd_dr_prediction_z{1, 2, 3}_avx2
+ * - av1_dr_prediction_z{1, 2, 3}_avx2
+ *
+ * @author Cidana-Wenyao
+ *
+ ******************************************************************************/
+
+#include "gtest/gtest.h"
+#include "aom_dsp_rtcd.h"
+#include "EbDefinitions.h"
+#include "random.h"
+
+namespace {
+using svt_av1_test_tool::SVTRandom;
+
+// copied from EbIntraPrediction.c
+const uint16_t dr_intra_derivative[90] = {
+    // More evenly spread out angles and limited to 10-bit
+    // Values that are 0 will never be used
+    //                    Approx angle
+    0,    0, 0,        //
+    1023, 0, 0,        // 3, ...
+    547,  0, 0,        // 6, ...
+    372,  0, 0, 0, 0,  // 9, ...
+    273,  0, 0,        // 14, ...
+    215,  0, 0,        // 17, ...
+    178,  0, 0,        // 20, ...
+    151,  0, 0,        // 23, ... (113 & 203 are base angles)
+    132,  0, 0,        // 26, ...
+    116,  0, 0,        // 29, ...
+    102,  0, 0, 0,     // 32, ...
+    90,   0, 0,        // 36, ...
+    80,   0, 0,        // 39, ...
+    71,   0, 0,        // 42, ...
+    64,   0, 0,        // 45, ... (45 & 135 are base angles)
+    57,   0, 0,        // 48, ...
+    51,   0, 0,        // 51, ...
+    45,   0, 0, 0,     // 54, ...
+    40,   0, 0,        // 58, ...
+    35,   0, 0,        // 61, ...
+    31,   0, 0,        // 64, ...
+    27,   0, 0,        // 67, ... (67 & 157 are base angles)
+    23,   0, 0,        // 70, ...
+    19,   0, 0,        // 73, ...
+    15,   0, 0, 0, 0,  // 76, ...
+    11,   0, 0,        // 81, ...
+    7,    0, 0,        // 84, ...
+    3,    0, 0,        // 87, ...
+};
+
+static INLINE uint16_t get_dy(int32_t angle) {
+    if (angle > 90 && angle < 180) {
+        return dr_intra_derivative[angle - 90];
+    } else if (angle > 180 && angle < 270) {
+        return dr_intra_derivative[270 - angle];
+    } else {
+        // In this case, we are not really going to use dy. We may return any
+        // value.
+        return 1;
+    }
+}
+// Get the shift (up-scaled by 256) in X w.r.t a unit change in Y.
+// If angle > 0 && angle < 90, dx = -((int32_t)(256 / t));
+// If angle > 90 && angle < 180, dx = (int32_t)(256 / t);
+// If angle > 180 && angle < 270, dx = 1;
+static INLINE uint16_t get_dx(int32_t angle) {
+    if (angle > 0 && angle < 90) {
+        return dr_intra_derivative[angle];
+    } else if (angle > 90 && angle < 180) {
+        return dr_intra_derivative[180 - angle];
+    } else {
+        // In this case, we are not really going to use dx. We may return any
+        // value.
+        return 1;
+    }
+}
+
+// define the function types
+using Z1_LBD = void (*)(uint8_t *dst, ptrdiff_t stride, int bw, int bh,
+                        const uint8_t *above, const uint8_t *left,
+                        int upsample_above, int dx, int dy);
+
+using Z2_LBD = void (*)(uint8_t *dst, ptrdiff_t stride, int bw, int bh,
+                        const uint8_t *above, const uint8_t *left,
+                        int upsample_above, int upsample_left, int dx, int dy);
+
+using Z3_LBD = void (*)(uint8_t *dst, ptrdiff_t stride, int bw, int bh,
+                        const uint8_t *above, const uint8_t *left,
+                        int upsample_left, int dx, int dy);
+
+using Z1_HBD = void (*)(uint16_t *dst, ptrdiff_t stride, int bw, int bh,
+                        const uint16_t *above, const uint16_t *left,
+                        int upsample_above, int dx, int dy, int bd);
+
+using Z2_HBD = void (*)(uint16_t *dst, ptrdiff_t stride, int bw, int bh,
+                        const uint16_t *above, const uint16_t *left,
+                        int upsample_above, int upsample_left, int dx, int dy,
+                        int bd);
+using Z3_HBD = void (*)(uint16_t *dst, ptrdiff_t stride, int bw, int bh,
+                        const uint16_t *above, const uint16_t *left,
+                        int upsample_left, int dx, int dy, int bd);
+/**
+ * @brief Unit test for intra directional prediction:
+ * - av1_highbd_dr_prediction_z{1, 2, 3}_avx2
+ * - av1_dr_prediction_z{1, 2, 3}_avx2
+ *
+ * Test strategy:
+ * Verify this assembly code by comparing with reference c implementation.
+ * Feed the same data and check test output and reference output.
+ * Define a templete class to handle the common process, and
+ * declare sub class to handle different bitdepth and function types.
+ *
+ * Expect result:
+ * Output from assemble functions should be the same with output from c.
+ *
+ * Test coverage:
+ * Test cases:
+ * Neighbor pixel buffer: Fill with random values
+ * TxSize: all the TxSize.
+ * BitDepth: 8bit and 10bit
+ *
+ */
+template <typename Pixel, typename FuncType>
+class DrPredTest {
+  public:
+    static const int num_tests = 10;
+    static const int pred_buf_size = MAX_TX_SQUARE;
+    static const int start_offset = 16;
+    static const int neighbor_buf_size = ((2 * MAX_TX_SIZE) << 1) + 16;
+    static const int z1_start_angle = 0;
+    static const int z2_start_angle = 90;
+    static const int z3_start_angle = 180;
+
+    DrPredTest() {
+        start_angle_ = 0;
+        stop_angle_ = 0 + 90;
+        ref_func_ = tst_func_ = nullptr;
+        bd_ = 8;
+        common_init();
+    }
+
+    virtual ~DrPredTest() {
+    }
+
+    void RunAllTest() {
+        for (int angle = start_angle_; angle < stop_angle_; ++angle) {
+            dx_ = get_dx(angle);
+            dy_ = get_dy(angle);
+            if (dx_ & dy_)
+                RunTest();
+        }
+    }
+
+  protected:
+    void common_init() {
+        upsample_above_ = upsample_left_ = 0;
+        bw_ = bh_ = 0;
+        dx_ = dy_ = 1;
+        dst_ref_ = &dst_ref_data_[0];
+        dst_tst_ = &dst_tst_data_[0];
+        dst_stride_ = MAX_TX_SIZE;
+        above_ = &above_data_[start_offset];
+        left_ = &left_data_[start_offset];
+    }
+
+    virtual void Predict() {
+    }
+
+    void prepare_neighbor_pixel(SVTRandom &rnd, int cnt) {
+        if (cnt == 0) {
+            for (int i = 0; i < neighbor_buf_size; ++i)
+                above_data_[i] = left_data_[i] = (1 << bd_) - 1;
+        } else {
+            for (int i = 0; i < neighbor_buf_size; ++i) {
+                above_data_[i] = rnd.random();
+                left_data_[i] = rnd.random();
+            }
+        }
+    }
+
+    void clear_output_pixel() {
+        for (int i = 0; i < pred_buf_size; ++i)
+            dst_ref_[i] = 0;
+
+        for (int i = 0; i < pred_buf_size; ++i)
+            dst_tst_[i] = 0;
+    }
+
+    void RunTest() {
+        SVTRandom rnd(0, (1 << bd_) - 1);
+        for (int cnt = 0; cnt < num_tests; ++cnt) {
+            prepare_neighbor_pixel(rnd, cnt);
+            for (int tx = 0; tx < TX_SIZES_ALL; ++tx) {
+                // clear the output for each tx
+                clear_output_pixel();
+                bw_ = tx_size_wide[tx];
+                bh_ = tx_size_high[tx];
+
+                Predict();
+
+                // check the result
+                for (int r = 0; r < bh_; ++r) {
+                    for (int c = 0; c < bw_; ++c) {
+                        ASSERT_EQ(dst_ref_[r * dst_stride_ + c],
+                                  dst_tst_[r * dst_stride_ + c])
+                            << bw_ << "x" << bh_ << " r: " << r << " c: " << c
+                            << " dx: " << dx_ << " dy: " << dy_
+                            << " upsample_above: " << upsample_above_
+                            << " upsample_left: " << upsample_left_;
+                    }
+                }
+            }
+        }
+    }
+
+    Pixel dst_ref_data_[pred_buf_size];
+    Pixel dst_tst_data_[pred_buf_size];
+
+    Pixel left_data_[neighbor_buf_size];
+    Pixel above_data_[neighbor_buf_size];
+
+    Pixel *dst_ref_;
+    Pixel *dst_tst_;
+    Pixel *above_;
+    Pixel *left_;
+    int dst_stride_;
+
+    int upsample_above_;
+    int upsample_left_;
+    int bw_;
+    int bh_;
+    int dx_;
+    int dy_;
+    int bd_;
+
+    int start_angle_;
+    int stop_angle_;
+
+    FuncType ref_func_;
+    FuncType tst_func_;
+};
+
+class LowbdZ1PredTest : public DrPredTest<uint8_t, Z1_LBD> {
+  public:
+    LowbdZ1PredTest() {
+        start_angle_ = z1_start_angle;
+        stop_angle_ = start_angle_ + 90;
+        ref_func_ = av1_dr_prediction_z1_c;
+        tst_func_ = av1_dr_prediction_z1_avx2;
+        bd_ = 8;
+
+        common_init();
+    }
+
+  protected:
+    void Predict() override {
+        ref_func_(dst_ref_,
+                  dst_stride_,
+                  bw_,
+                  bh_,
+                  above_,
+                  left_,
+                  upsample_above_,
+                  dx_,
+                  dy_);
+        tst_func_(dst_tst_,
+                  dst_stride_,
+                  bw_,
+                  bh_,
+                  above_,
+                  left_,
+                  upsample_above_,
+                  dx_,
+                  dy_);
+    }
+};
+
+class LowbdZ2PredTest : public DrPredTest<uint8_t, Z2_LBD> {
+  public:
+    LowbdZ2PredTest() {
+        start_angle_ = z2_start_angle;
+        stop_angle_ = start_angle_ + 90;
+        ref_func_ = av1_dr_prediction_z2_c;
+        tst_func_ = av1_dr_prediction_z2_avx2;
+        bd_ = 8;
+
+        common_init();
+    }
+
+  protected:
+    void Predict() override {
+        ref_func_(dst_ref_,
+                  dst_stride_,
+                  bw_,
+                  bh_,
+                  above_,
+                  left_,
+                  upsample_above_,
+                  upsample_left_,
+                  dx_,
+                  dy_);
+        tst_func_(dst_tst_,
+                  dst_stride_,
+                  bw_,
+                  bh_,
+                  above_,
+                  left_,
+                  upsample_above_,
+                  upsample_left_,
+                  dx_,
+                  dy_);
+    }
+};
+
+class LowbdZ3PredTest : public DrPredTest<uint8_t, Z3_LBD> {
+  public:
+    LowbdZ3PredTest() {
+        start_angle_ = z3_start_angle;
+        stop_angle_ = start_angle_ + 90;
+        ref_func_ = av1_dr_prediction_z3_c;
+        tst_func_ = av1_dr_prediction_z3_avx2;
+        bd_ = 8;
+
+        common_init();
+    }
+
+  protected:
+    void Predict() override {
+        ref_func_(dst_ref_,
+                  dst_stride_,
+                  bw_,
+                  bh_,
+                  above_,
+                  left_,
+                  upsample_left_,
+                  dx_,
+                  dy_);
+        tst_func_(dst_tst_,
+                  dst_stride_,
+                  bw_,
+                  bh_,
+                  above_,
+                  left_,
+                  upsample_left_,
+                  dx_,
+                  dy_);
+    }
+};
+
+#define TEST_CLASS(tc_name, type_name)        \
+    TEST(tc_name, match_test) {               \
+        type_name *dr_test = new type_name(); \
+        dr_test->RunAllTest();                \
+        delete dr_test;                       \
+    }
+
+TEST_CLASS(LowbdDrZ1Test, LowbdZ1PredTest)
+TEST_CLASS(LowbdDrZ2Test, LowbdZ2PredTest)
+TEST_CLASS(LowbdDrZ3Test, LowbdZ3PredTest)
+
+class HighbdZ1PredTest : public DrPredTest<uint16_t, Z1_HBD> {
+  public:
+    HighbdZ1PredTest() {
+        start_angle_ = z1_start_angle;
+        stop_angle_ = start_angle_ + 90;
+        ref_func_ = av1_highbd_dr_prediction_z1_c;
+        tst_func_ = av1_highbd_dr_prediction_z1_avx2;
+        bd_ = 10;
+
+        common_init();
+    }
+
+  protected:
+    void Predict() override {
+        ref_func_(dst_ref_,
+                  dst_stride_,
+                  bw_,
+                  bh_,
+                  above_,
+                  left_,
+                  upsample_above_,
+                  dx_,
+                  dy_,
+                  bd_);
+        tst_func_(dst_tst_,
+                  dst_stride_,
+                  bw_,
+                  bh_,
+                  above_,
+                  left_,
+                  upsample_above_,
+                  dx_,
+                  dy_,
+                  bd_);
+    }
+};
+
+class HighbdZ2PredTest : public DrPredTest<uint16_t, Z2_HBD> {
+  public:
+    HighbdZ2PredTest() {
+        start_angle_ = z2_start_angle;
+        stop_angle_ = start_angle_ + 90;
+        ref_func_ = av1_highbd_dr_prediction_z2_c;
+        tst_func_ = av1_highbd_dr_prediction_z2_avx2;
+        bd_ = 10;
+
+        common_init();
+    }
+
+  protected:
+    void Predict() override {
+        ref_func_(dst_ref_,
+                  dst_stride_,
+                  bw_,
+                  bh_,
+                  above_,
+                  left_,
+                  upsample_above_,
+                  upsample_left_,
+                  dx_,
+                  dy_,
+                  bd_);
+        tst_func_(dst_tst_,
+                  dst_stride_,
+                  bw_,
+                  bh_,
+                  above_,
+                  left_,
+                  upsample_above_,
+                  upsample_left_,
+                  dx_,
+                  dy_,
+                  bd_);
+    }
+};
+
+class HighbdZ3PredTest : public DrPredTest<uint16_t, Z3_HBD> {
+  public:
+    HighbdZ3PredTest() {
+        start_angle_ = z3_start_angle;
+        stop_angle_ = start_angle_ + 90;
+        ref_func_ = av1_highbd_dr_prediction_z3_c;
+        tst_func_ = av1_highbd_dr_prediction_z3_avx2;
+        bd_ = 10;
+
+        common_init();
+    }
+
+  protected:
+    void Predict() override {
+        ref_func_(dst_ref_,
+                  dst_stride_,
+                  bw_,
+                  bh_,
+                  above_,
+                  left_,
+                  upsample_left_,
+                  dx_,
+                  dy_,
+                  bd_);
+        tst_func_(dst_tst_,
+                  dst_stride_,
+                  bw_,
+                  bh_,
+                  above_,
+                  left_,
+                  upsample_left_,
+                  dx_,
+                  dy_,
+                  bd_);
+    }
+};
+
+TEST_CLASS(HighbdDrZ1Test, HighbdZ1PredTest)
+TEST_CLASS(HighbdDrZ2Test, HighbdZ2PredTest)
+TEST_CLASS(HighbdDrZ3Test, HighbdZ3PredTest)
+
+}  // namespace

--- a/test/intrapred_edge_filter_test.cc
+++ b/test/intrapred_edge_filter_test.cc
@@ -1,0 +1,282 @@
+/*
+ * Copyright(c) 2019 Netflix, Inc.
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+/******************************************************************************
+ * @file intrapred_edge_filter_test.cc
+ *
+ * @brief Unit test for upsample and edge filter:
+ * - av1_upsample_intra_edge_sse4_1
+ * - av1_filter_intra_edge_sse4_1
+ * - av1_filter_intra_edge_high_sse4_1
+ *
+ * @author Cidana-Wenyao
+ *
+ ******************************************************************************/
+
+#include "gtest/gtest.h"
+#include "aom_dsp_rtcd.h"
+#include "EbDefinitions.h"
+#include "random.h"
+
+namespace {
+using svt_av1_test_tool::SVTRandom;
+
+// -----------------------------------------------------------------------------
+// Upsample test
+using UPSAMPLE_LBD = void (*)(uint8_t *p, int size);
+
+/**
+ * @brief Unit test for upsample in intra prediction specified in
+ * spec 7.11.2.11:
+ * - av1_upsample_intra_edge_sse4_1
+ *
+ * Test strategy:
+ * Verify this assembly code by comparing with reference c implementation.
+ * Feed the same data and check test output and reference output.
+ * Define a templete class to handle the common process, and
+ * declare sub class to handle different bitdepth and function types.
+ *
+ * Expect result:
+ * Output from assemble functions should be the same with output from c.
+ *
+ * Test coverage:
+ * Test cases:
+ * Neighbor pixel buffer: Fill with random values
+ * numPx: [4, 16] (w + (pAngle < 90 ? h : 0)) and and max blkWh is 16
+ * according to spec 7.11.2
+ * BitDepth: 8bit
+ */
+template <typename Pixel, typename Func>
+class UpsampleTest {
+  public:
+    UpsampleTest() {
+        ref_func_ = nullptr;
+        tst_func_ = nullptr;
+        bd_ = 8;
+        common_init();
+    }
+
+    virtual ~UpsampleTest() {
+    }
+
+    void RunTest() {
+        SVTRandom pix_rnd(0, (1 << bd_) - 1);
+        for (int iter = 0; iter < num_tests; ++iter) {
+            for (int i = 1; i < 5; ++i) {  // [1, 4]
+                numPx_ = 4 * i;            // blkWh is increased with step 4.
+                prepare_data(pix_rnd);
+
+                run_upsample();
+
+                // When the process completes, entries -2 to 2*numPx-2
+                // are valid in buf;
+                const int max_idx = (numPx_ - 1) * 2;
+                for (int i = -2; i <= max_idx; ++i)
+                    ASSERT_EQ(edge_ref_[i], edge_tst_[i]);
+            }
+        }
+    }
+
+  protected:
+    static const int num_tests = 1000000;
+    static const int edge_buf_size = 2 * 64 + 32;
+    static const int start_offset = 16;
+
+    void common_init() {
+        edge_ref_ = &edge_ref_data_[start_offset];
+        edge_tst_ = &edge_tst_data_[start_offset];
+    }
+
+    void prepare_data(SVTRandom &pix_rnd) {
+        // When the process starts, entries -1 to numPx-1 are valid in buf
+        int i = 0;
+        for (; i < start_offset + numPx_; ++i)
+            edge_ref_data_[i] = edge_tst_data_[i] = pix_rnd.random();
+
+        Pixel last = edge_ref_data_[start_offset + numPx_ - 1];
+        for (; i < edge_buf_size; ++i)
+            edge_ref_data_[i] = edge_tst_data_[i] = last;
+    }
+
+    virtual void run_upsample() {
+    }
+
+    Pixel edge_ref_data_[edge_buf_size];
+    Pixel edge_tst_data_[edge_buf_size];
+
+    Pixel *edge_ref_;
+    Pixel *edge_tst_;
+
+    Func ref_func_;
+    Func tst_func_;
+    int numPx_;
+    int bd_;
+};
+
+class LowbdUpsampleTest : public UpsampleTest<uint8_t, UPSAMPLE_LBD> {
+  public:
+    LowbdUpsampleTest() {
+        ref_func_ = av1_upsample_intra_edge_c;
+        tst_func_ = av1_upsample_intra_edge_sse4_1;
+        bd_ = 8;
+        common_init();
+    }
+
+  protected:
+    void run_upsample() override {
+        ref_func_(edge_ref_, numPx_);
+        tst_func_(edge_tst_, numPx_);
+    }
+};
+
+#define TEST_CLASS(tc_name, type_name)     \
+    TEST(tc_name, match_test) {            \
+        type_name *test = new type_name(); \
+        test->RunTest();                   \
+        delete test;                       \
+    }
+
+TEST_CLASS(UpsampleTestLBD, LowbdUpsampleTest)
+
+// -----------------------------------------------------------------------------
+// Filter edge Tests
+// Declare macros and functions requried
+#define INTRA_EDGE_FILT 3
+#define INTRA_EDGE_TAPS 5
+#define MAX_UPSAMPLE_SZ 16
+static void av1_filter_intra_edge_c(uint8_t *p, int sz, int strength) {
+    if (!strength)
+        return;
+
+    const int kernel[INTRA_EDGE_FILT][INTRA_EDGE_TAPS] = {
+        {0, 4, 8, 4, 0}, {0, 5, 6, 5, 0}, {2, 4, 4, 4, 2}};
+    const int filt = strength - 1;
+    uint8_t edge[129];
+
+    memcpy(edge, p, sz * sizeof(*p));
+    for (int i = 1; i < sz; i++) {
+        int s = 0;
+        for (int j = 0; j < INTRA_EDGE_TAPS; j++) {
+            int k = i - 2 + j;
+            k = (k < 0) ? 0 : k;
+            k = (k > sz - 1) ? sz - 1 : k;
+            s += edge[k] * kernel[filt][j];
+        }
+        s = (s + 8) >> 4;
+        p[i] = s;
+    }
+}
+
+using FILTER_EDGE_LBD = void (*)(uint8_t *p, int size, int strength);
+using FILTER_EDGE_HBD = void (*)(uint16_t *p, int size, int strength);
+
+/**
+ * @brief Unit test for edge filter in intra prediction:
+ * - av1_filter_intra_edge_sse4_1
+ * - av1_filter_intra_edge_high_sse4_1
+ *
+ * Test strategy:
+ * Verify this assembly code by comparing with reference c implementation.
+ * Feed the same data and check test output and reference output.
+ * Define a templete class to handle the common process, and
+ * declare sub class to handle different bitdepth and function types.
+ *
+ * Expect result:
+ * Output from assemble functions should be the same with output from c.
+ *
+ * Test coverage:
+ * Test cases:
+ * Neighbor pixel buffer: Fill with random values
+ * Strength: [0, 3] // spec 7.11.2.9 Intra edge filter strength selection
+ * numPx: [5, 129] // Min(w, (MaxX-x+1)) + (pAngle < 90 ? h : 0) + 1
+ * BitDepth: 8bit and 10bit
+ */
+template <typename Pixel, typename Func>
+class FilterEdgeTest {
+  public:
+    FilterEdgeTest() {
+        ref_func_ = tst_func_ = nullptr;
+        bd_ = 8;
+        common_init();
+    }
+
+    virtual ~FilterEdgeTest() {
+    }
+
+    void RunTest() {
+        SVTRandom numPx_rnd(1, 32);    // range [1, 32]
+        SVTRandom strength_rnd(0, 3);  // range [0, 3]
+        SVTRandom pix_rnd(0, (1 << bd_) - 1);
+        for (int iter = 0; iter < num_tests; ++iter) {
+            // random strength and size
+            strength_ = strength_rnd.random();
+            numPx_ = 4 * numPx_rnd.random() + 1;
+
+            prepare_data(pix_rnd);
+
+            run_filter_edge();
+
+            for (int i = 0; i < numPx_; ++i)
+                ASSERT_EQ(edge_ref_[i], edge_tst_[i]);
+        }
+    }
+
+  protected:
+    static const int num_tests = 1000000;
+    static const int edge_buf_size = 2 * MAX_TX_SIZE + 32;
+    static const int start_offset = 15;
+
+    void common_init() {
+        edge_ref_ = &edge_ref_data_[start_offset];
+        edge_tst_ = &edge_tst_data_[start_offset];
+    }
+
+    void prepare_data(SVTRandom &pix_rnd) {
+        int i = 0;
+        for (; i < start_offset + numPx_; ++i)
+            edge_ref_data_[i] = edge_tst_data_[i] = pix_rnd.random();
+    }
+
+    void run_filter_edge() {
+        ref_func_(edge_ref_, numPx_, strength_);
+        tst_func_(edge_tst_, numPx_, strength_);
+    }
+
+    Pixel edge_ref_data_[edge_buf_size];
+    Pixel edge_tst_data_[edge_buf_size];
+
+    Pixel *edge_ref_;
+    Pixel *edge_tst_;
+
+    Func ref_func_;
+    Func tst_func_;
+    int numPx_;
+    int bd_;
+    int strength_;
+};
+
+class LowbdFilterEdgeTest : public FilterEdgeTest<uint8_t, FILTER_EDGE_LBD> {
+  public:
+    LowbdFilterEdgeTest() {
+        ref_func_ = av1_filter_intra_edge_c;
+        tst_func_ = av1_filter_intra_edge_sse4_1;
+        bd_ = 8;
+        common_init();
+    }
+};
+
+class HighbdFilterEdgeTest : public FilterEdgeTest<uint16_t, FILTER_EDGE_HBD> {
+  public:
+    HighbdFilterEdgeTest() {
+        ref_func_ = av1_filter_intra_edge_high_c;
+        tst_func_ = av1_filter_intra_edge_high_sse4_1;
+        bd_ = 10;
+        common_init();
+    }
+};
+
+TEST_CLASS(IntraFilterEdgeTestLowbd, LowbdFilterEdgeTest)
+TEST_CLASS(IntraFilterEdgeTestHighbd, HighbdFilterEdgeTest)
+}  // namespace

--- a/test/intrapred_test.cc
+++ b/test/intrapred_test.cc
@@ -1,0 +1,380 @@
+/*
+ * Copyright(c) 2019 Netflix, Inc.
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+/******************************************************************************
+ * @file intrapred_test.cc
+ *
+ * @brief Unit test for intra {h, v}_pred, dc_pred, smooth_{h, v}_pred :
+ * - av1_highbd_{dc, h, v, smooth_h, smooth_v}_predictor_wxh_{sse2, avx2, ssse3}
+ * - av1_{dc, h, v, smooth_h, smooth_v}_predictor_wxh_{sse2, avx2, ssse3}
+ *
+ * @author Cidana-Wenyao
+ *
+ ******************************************************************************/
+
+#include "gtest/gtest.h"
+#include "aom_dsp_rtcd.h"
+#include "EbDefinitions.h"
+#include "random.h"
+
+namespace {
+using std::get;
+using std::make_tuple;
+using std::tuple;
+using svt_av1_test_tool::SVTRandom;
+
+const int count_test_block = 1000;
+
+using INTRAPRED_HBD = void (*)(uint16_t *dst, ptrdiff_t stride,
+                               const uint16_t *above, const uint16_t *left,
+                               int bd);
+using INTRAPRED_LBD = void (*)(uint8_t *dst, ptrdiff_t stride,
+                               const uint8_t *above, const uint8_t *left);
+
+using LBD_PARAMS = tuple<INTRAPRED_LBD, INTRAPRED_LBD, int, int, int>;
+using HBD_PARAMS = tuple<INTRAPRED_HBD, INTRAPRED_HBD, int, int, int>;
+
+/**
+ * @brief Unit test for intra prediction:
+ * - av1_highbd_{dc, h, v, smooth_h, smooth_v}_predictor_wxh_{sse2, avx2, ssse3}
+ * - av1_{dc, h, v, smooth_h, smooth_v}_predictor_wxh_{sse2, avx2, ssse3}
+ *
+ * Test strategy:
+ * Verify this assembly code by comparing with reference c implementation.
+ * Feed the same data and check test output and reference output.
+ * Define a templete class to handle the common process, and
+ * declare sub class to handle different bitdepth and function types.
+ *
+ * Expect result:
+ * Output from assemble functions should be the same with output from c.
+ *
+ * Test coverage:
+ * Test cases:
+ * Neighbor pixel buffer: Fill with random values
+ * TxSize: all the TxSize.
+ * BitDepth: 8bit and 10bit
+ *
+ */
+template <typename FuncType, typename Pixel, typename TupleType>
+class AV1IntraPredTest : public ::testing::TestWithParam<TupleType> {
+  protected:
+    void prepare_data(SVTRandom &rnd, int cnt) {
+        if (cnt == 0) {
+            for (int x = -1; x <= bw_ * 2; x++)
+                above_row_[x] = (1 << bd_) - 1;
+
+            for (int y = 0; y < bh_; y++)
+                left_col_[y] = (1 << bd_) - 1;
+        } else {
+            for (int x = -1; x <= bw_ * 2; x++)
+                above_row_[x] = rnd.random();
+
+            for (int y = 0; y < bh_; y++)
+                left_col_[y] = rnd.random();
+        }
+        memset(dst_tst_data_, 0, sizeof(dst_tst_data_));
+        memset(dst_ref_data_, 0, sizeof(dst_ref_data_));
+    }
+
+  public:
+    void RunTest() {
+        SVTRandom rnd(0, (1 << bd_) - 1);
+        for (int i = 0; i < count_test_block; ++i) {
+            // prepare the neighbor pixels
+            prepare_data(rnd, i);
+
+            Predict();
+
+            for (int y = 0; y < bh_; y++) {
+                for (int x = 0; x < bw_; x++) {
+                    ASSERT_EQ(dst_ref_[x + y * stride_],
+                              dst_tst_[x + y * stride_])
+                        << " Failed on loop " << i << " location: x = " << x
+                        << " y = " << y;
+                }
+            }
+        }
+    }
+
+  protected:
+    void SetUp() override {
+        params_ = this->GetParam();
+        tst_func_ = get<0>(params_);
+        ref_func_ = get<1>(params_);
+        bw_ = get<2>(params_);
+        bh_ = get<3>(params_);
+        bd_ = get<4>(params_);
+        stride_ = bw_ * 3;
+        mask_ = (1 << bd_) - 1;
+        above_row_ = above_row_data_ + 16;
+        left_col_ = left_col_data_;
+        dst_tst_ = dst_tst_data_;
+        dst_ref_ = dst_ref_data_;
+    }
+
+    virtual void Predict() = 0;
+
+    Pixel *above_row_;
+    Pixel *left_col_;
+    Pixel *dst_tst_;
+    Pixel *dst_ref_;
+    DECLARE_ALIGNED(16, Pixel, left_col_data_[2 * 64]);
+    DECLARE_ALIGNED(16, Pixel, above_row_data_[2 * 64 + 64]);
+    DECLARE_ALIGNED(16, Pixel, dst_tst_data_[3 * 64 * 64]);
+    DECLARE_ALIGNED(16, Pixel, dst_ref_data_[3 * 64 * 64]);
+
+    ptrdiff_t stride_;
+    int bw_;  // block width
+    int bh_;  // block height
+    int mask_;
+    FuncType tst_func_;
+    FuncType ref_func_;
+    int bd_;
+
+    TupleType params_;
+};
+
+class HighbdIntraPredTest
+    : public AV1IntraPredTest<INTRAPRED_HBD, uint16_t, HBD_PARAMS> {
+  protected:
+    void Predict() {
+        const int bit_depth = bd_;
+        ref_func_(dst_ref_, stride_, above_row_, left_col_, bit_depth);
+        tst_func_(dst_tst_, stride_, above_row_, left_col_, bit_depth);
+    }
+};
+
+class LowbdIntraPredTest
+    : public AV1IntraPredTest<INTRAPRED_LBD, uint8_t, LBD_PARAMS> {
+  protected:
+    void Predict() {
+        ref_func_(dst_ref_, stride_, above_row_, left_col_);
+        tst_func_(dst_tst_, stride_, above_row_, left_col_);
+    }
+};
+
+TEST_P(HighbdIntraPredTest, match_test) {
+    RunTest();
+}
+
+TEST_P(LowbdIntraPredTest, match_test) {
+    RunTest();
+}
+
+// -----------------------------------------------------------------------------
+// High Bit Depth Tests
+#define hbd_entry(type, width, height, opt)                               \
+    make_tuple(&aom_highbd_##type##_predictor_##width##x##height##_##opt, \
+               &aom_highbd_##type##_predictor_##width##x##height##_c,     \
+               width,                                                     \
+               height,                                                    \
+               10)
+
+const HBD_PARAMS HighbdIntraPredTestVectorAsm[] = {
+    hbd_entry(dc_128, 16, 16, avx2),   hbd_entry(dc_128, 16, 32, avx2),
+    hbd_entry(dc_128, 16, 4, avx2),    hbd_entry(dc_128, 16, 64, avx2),
+    hbd_entry(dc_128, 16, 8, avx2),    hbd_entry(dc_128, 32, 16, avx2),
+    hbd_entry(dc_128, 32, 32, avx2),   hbd_entry(dc_128, 32, 64, avx2),
+    hbd_entry(dc_128, 32, 8, avx2),    hbd_entry(dc_128, 4, 16, sse2),
+    hbd_entry(dc_128, 4, 4, sse2),     hbd_entry(dc_128, 4, 8, sse2),
+    hbd_entry(dc_128, 64, 16, avx2),   hbd_entry(dc_128, 64, 32, avx2),
+    hbd_entry(dc_128, 64, 64, avx2),   hbd_entry(dc_128, 8, 16, sse2),
+    hbd_entry(dc_128, 8, 32, sse2),    hbd_entry(dc_128, 8, 4, sse2),
+    hbd_entry(dc_128, 8, 8, sse2),     hbd_entry(dc_left, 16, 16, avx2),
+    hbd_entry(dc_left, 16, 32, avx2),  hbd_entry(dc_left, 16, 4, avx2),
+    hbd_entry(dc_left, 16, 64, avx2),  hbd_entry(dc_left, 16, 8, avx2),
+    hbd_entry(dc_left, 32, 16, avx2),  hbd_entry(dc_left, 32, 32, avx2),
+    hbd_entry(dc_left, 32, 64, avx2),  hbd_entry(dc_left, 32, 8, avx2),
+    hbd_entry(dc_left, 4, 16, sse2),   hbd_entry(dc_left, 4, 4, sse2),
+    hbd_entry(dc_left, 4, 8, sse2),    hbd_entry(dc_left, 64, 16, avx2),
+    hbd_entry(dc_left, 64, 32, avx2),  hbd_entry(dc_left, 64, 64, avx2),
+    hbd_entry(dc_left, 8, 16, sse2),   hbd_entry(dc_left, 8, 32, sse2),
+    hbd_entry(dc_left, 8, 4, sse2),    hbd_entry(dc_left, 8, 8, sse2),
+    hbd_entry(dc, 16, 16, avx2),       hbd_entry(dc, 16, 32, avx2),
+    hbd_entry(dc, 16, 4, avx2),        hbd_entry(dc, 16, 64, avx2),
+    hbd_entry(dc, 16, 8, avx2),        hbd_entry(dc, 32, 16, avx2),
+    hbd_entry(dc, 32, 32, avx2),       hbd_entry(dc, 32, 64, avx2),
+    hbd_entry(dc, 32, 8, avx2),        hbd_entry(dc, 4, 16, sse2),
+    hbd_entry(dc, 4, 4, sse2),         hbd_entry(dc, 4, 8, sse2),
+    hbd_entry(dc, 64, 16, avx2),       hbd_entry(dc, 64, 32, avx2),
+    hbd_entry(dc, 64, 64, avx2),       hbd_entry(dc, 8, 16, sse2),
+    hbd_entry(dc, 8, 32, sse2),        hbd_entry(dc, 8, 4, sse2),
+    hbd_entry(dc, 8, 8, sse2),         hbd_entry(dc_top, 16, 16, avx2),
+    hbd_entry(dc_top, 16, 32, avx2),   hbd_entry(dc_top, 16, 4, avx2),
+    hbd_entry(dc_top, 16, 64, avx2),   hbd_entry(dc_top, 16, 8, avx2),
+    hbd_entry(dc_top, 32, 16, avx2),   hbd_entry(dc_top, 32, 32, avx2),
+    hbd_entry(dc_top, 32, 64, avx2),   hbd_entry(dc_top, 32, 8, avx2),
+    hbd_entry(dc_top, 4, 16, sse2),    hbd_entry(dc_top, 4, 4, sse2),
+    hbd_entry(dc_top, 4, 8, sse2),     hbd_entry(dc_top, 64, 16, avx2),
+    hbd_entry(dc_top, 64, 32, avx2),   hbd_entry(dc_top, 64, 64, avx2),
+    hbd_entry(dc_top, 8, 16, sse2),    hbd_entry(dc_top, 8, 4, sse2),
+    hbd_entry(dc_top, 8, 8, sse2),     hbd_entry(h, 16, 16, sse2),
+    hbd_entry(h, 16, 32, sse2),        hbd_entry(h, 16, 4, avx2),
+    hbd_entry(h, 16, 64, avx2),        hbd_entry(h, 16, 8, sse2),
+    hbd_entry(h, 32, 16, sse2),        hbd_entry(h, 32, 32, sse2),
+    hbd_entry(h, 32, 64, avx2),        hbd_entry(h, 32, 8, avx2),
+    hbd_entry(h, 4, 16, sse2),         hbd_entry(h, 4, 4, sse2),
+    hbd_entry(h, 4, 8, sse2),          hbd_entry(h, 64, 16, avx2),
+    hbd_entry(h, 64, 32, avx2),        hbd_entry(h, 64, 64, avx2),
+    hbd_entry(h, 8, 16, sse2),         hbd_entry(h, 8, 32, sse2),
+    hbd_entry(h, 8, 4, sse2),          hbd_entry(h, 8, 8, sse2),
+    hbd_entry(smooth_h, 16, 16, avx2), hbd_entry(smooth_h, 16, 32, avx2),
+    hbd_entry(smooth_h, 16, 4, avx2),  hbd_entry(smooth_h, 16, 64, avx2),
+    hbd_entry(smooth_h, 16, 8, avx2),  hbd_entry(smooth_h, 32, 16, avx2),
+    hbd_entry(smooth_h, 32, 32, avx2), hbd_entry(smooth_h, 32, 64, avx2),
+    hbd_entry(smooth_h, 32, 8, avx2),  hbd_entry(smooth_h, 4, 16, ssse3),
+    hbd_entry(smooth_h, 4, 4, ssse3),  hbd_entry(smooth_h, 4, 8, ssse3),
+    hbd_entry(smooth_h, 64, 16, avx2), hbd_entry(smooth_h, 64, 32, avx2),
+    hbd_entry(smooth_h, 64, 64, avx2), hbd_entry(smooth_h, 8, 16, avx2),
+    hbd_entry(smooth_h, 8, 32, avx2),  hbd_entry(smooth_h, 8, 4, avx2),
+    hbd_entry(smooth_h, 8, 8, avx2),   hbd_entry(smooth, 16, 16, avx2),
+    hbd_entry(smooth, 16, 32, avx2),   hbd_entry(smooth, 16, 4, avx2),
+    hbd_entry(smooth, 16, 64, avx2),   hbd_entry(smooth, 16, 8, avx2),
+    hbd_entry(smooth, 32, 16, avx2),   hbd_entry(smooth, 32, 32, avx2),
+    hbd_entry(smooth, 32, 64, avx2),   hbd_entry(smooth, 32, 8, avx2),
+    hbd_entry(smooth, 4, 16, ssse3),   hbd_entry(smooth, 4, 4, ssse3),
+    hbd_entry(smooth, 4, 8, ssse3),    hbd_entry(smooth, 64, 16, avx2),
+    hbd_entry(smooth, 64, 32, avx2),   hbd_entry(smooth, 64, 64, avx2),
+    hbd_entry(smooth, 8, 16, avx2),    hbd_entry(smooth, 8, 32, avx2),
+    hbd_entry(smooth, 8, 4, avx2),     hbd_entry(smooth, 8, 8, avx2),
+    hbd_entry(smooth_v, 16, 16, avx2), hbd_entry(smooth_v, 16, 32, avx2),
+    hbd_entry(smooth_v, 16, 4, avx2),  hbd_entry(smooth_v, 16, 64, avx2),
+    hbd_entry(smooth_v, 16, 8, avx2),  hbd_entry(smooth_v, 32, 16, avx2),
+    hbd_entry(smooth_v, 32, 32, avx2), hbd_entry(smooth_v, 32, 64, avx2),
+    hbd_entry(smooth_v, 32, 8, avx2),  hbd_entry(smooth_v, 4, 16, ssse3),
+    hbd_entry(smooth_v, 4, 4, ssse3),  hbd_entry(smooth_v, 4, 8, ssse3),
+    hbd_entry(smooth_v, 64, 16, avx2), hbd_entry(smooth_v, 64, 32, avx2),
+    hbd_entry(smooth_v, 64, 64, avx2), hbd_entry(smooth_v, 8, 16, avx2),
+    hbd_entry(smooth_v, 8, 32, avx2),  hbd_entry(smooth_v, 8, 4, avx2),
+    hbd_entry(smooth_v, 8, 8, avx2),   hbd_entry(v, 16, 16, avx2),
+    hbd_entry(v, 16, 32, avx2),        hbd_entry(v, 16, 4, avx2),
+    hbd_entry(v, 16, 64, avx2),        hbd_entry(v, 16, 8, avx2),
+    hbd_entry(v, 32, 16, avx2),        hbd_entry(v, 32, 32, avx2),
+    hbd_entry(v, 32, 64, avx2),        hbd_entry(v, 32, 8, avx2),
+    hbd_entry(v, 4, 16, sse2),         hbd_entry(v, 4, 4, sse2),
+    hbd_entry(v, 4, 8, sse2),          hbd_entry(v, 64, 16, avx2),
+    hbd_entry(v, 64, 32, avx2),        hbd_entry(v, 64, 64, avx2),
+    hbd_entry(v, 8, 16, sse2),         hbd_entry(v, 8, 32, sse2),
+    hbd_entry(v, 8, 4, sse2),          hbd_entry(v, 8, 8, sse2),
+};
+
+INSTANTIATE_TEST_CASE_P(intrapred, HighbdIntraPredTest,
+                        ::testing::ValuesIn(HighbdIntraPredTestVectorAsm));
+
+// ---------------------------------------------------------------------------
+// Low Bit Depth Tests
+#define lbd_entry(type, width, height, opt)                        \
+    LBD_PARAMS(&aom_##type##_predictor_##width##x##height##_##opt, \
+               &aom_##type##_predictor_##width##x##height##_c,     \
+               width,                                              \
+               height,                                             \
+               8)
+
+const LBD_PARAMS LowbdIntraPredTestVectorAsm[] = {
+    lbd_entry(dc, 4, 4, sse2),          lbd_entry(dc, 8, 8, sse2),
+    lbd_entry(dc, 16, 16, sse2),        lbd_entry(dc, 32, 32, avx2),
+    lbd_entry(dc, 64, 64, avx2),        lbd_entry(dc, 16, 32, sse2),
+    lbd_entry(dc, 16, 4, sse2),         lbd_entry(dc, 16, 64, sse2),
+    lbd_entry(dc, 16, 8, sse2),         lbd_entry(dc, 32, 16, avx2),
+    lbd_entry(dc, 32, 64, avx2),        lbd_entry(dc, 32, 8, sse2),
+    lbd_entry(dc, 4, 16, sse2),         lbd_entry(dc, 4, 8, sse2),
+    lbd_entry(dc, 64, 16, avx2),        lbd_entry(dc, 64, 32, avx2),
+    lbd_entry(dc, 8, 16, sse2),         lbd_entry(dc, 8, 32, sse2),
+    lbd_entry(dc, 8, 4, sse2),          lbd_entry(dc_left, 4, 4, sse2),
+    lbd_entry(dc_left, 8, 8, sse2),     lbd_entry(dc_left, 16, 16, sse2),
+    lbd_entry(dc_left, 32, 32, avx2),   lbd_entry(dc_left, 64, 64, avx2),
+    lbd_entry(dc_left, 16, 32, sse2),   lbd_entry(dc_left, 16, 4, sse2),
+    lbd_entry(dc_left, 16, 64, sse2),   lbd_entry(dc_left, 16, 8, sse2),
+    lbd_entry(dc_left, 32, 16, avx2),   lbd_entry(dc_left, 32, 64, avx2),
+    lbd_entry(dc_left, 32, 8, sse2),    lbd_entry(dc_left, 4, 16, sse2),
+    lbd_entry(dc_left, 4, 8, sse2),     lbd_entry(dc_left, 64, 16, avx2),
+    lbd_entry(dc_left, 64, 32, avx2),   lbd_entry(dc_left, 8, 16, sse2),
+    lbd_entry(dc_left, 8, 32, sse2),    lbd_entry(dc_left, 8, 4, sse2),
+    lbd_entry(dc_top, 4, 4, sse2),      lbd_entry(dc_top, 8, 8, sse2),
+    lbd_entry(dc_top, 16, 16, sse2),    lbd_entry(dc_top, 32, 32, avx2),
+    lbd_entry(dc_top, 64, 64, avx2),    lbd_entry(dc_top, 16, 32, sse2),
+    lbd_entry(dc_top, 16, 4, sse2),     lbd_entry(dc_top, 16, 64, sse2),
+    lbd_entry(dc_top, 16, 8, sse2),     lbd_entry(dc_top, 32, 16, avx2),
+    lbd_entry(dc_top, 32, 64, avx2),    lbd_entry(dc_top, 32, 8, sse2),
+    lbd_entry(dc_top, 4, 16, sse2),     lbd_entry(dc_top, 4, 8, sse2),
+    lbd_entry(dc_top, 64, 16, avx2),    lbd_entry(dc_top, 64, 32, avx2),
+    lbd_entry(dc_top, 8, 16, sse2),     lbd_entry(dc_top, 8, 32, sse2),
+    lbd_entry(dc_top, 8, 4, sse2),      lbd_entry(dc_128, 4, 4, sse2),
+    lbd_entry(dc_128, 8, 8, sse2),      lbd_entry(dc_128, 16, 16, sse2),
+    lbd_entry(dc_128, 32, 32, avx2),    lbd_entry(dc_128, 64, 64, avx2),
+    lbd_entry(dc_128, 16, 32, sse2),    lbd_entry(dc_128, 16, 4, sse2),
+    lbd_entry(dc_128, 16, 64, sse2),    lbd_entry(dc_128, 16, 8, sse2),
+    lbd_entry(dc_128, 32, 16, avx2),    lbd_entry(dc_128, 32, 64, avx2),
+    lbd_entry(dc_128, 32, 8, sse2),     lbd_entry(dc_128, 4, 16, sse2),
+    lbd_entry(dc_128, 4, 8, sse2),      lbd_entry(dc_128, 64, 16, avx2),
+    lbd_entry(dc_128, 64, 32, avx2),    lbd_entry(dc_128, 8, 16, sse2),
+    lbd_entry(dc_128, 8, 32, sse2),     lbd_entry(dc_128, 8, 4, sse2),
+    lbd_entry(smooth_h, 64, 64, ssse3), lbd_entry(smooth_h, 32, 32, ssse3),
+    lbd_entry(smooth_h, 16, 16, ssse3), lbd_entry(smooth_h, 8, 8, ssse3),
+    lbd_entry(smooth_h, 4, 4, ssse3),   lbd_entry(smooth_h, 16, 32, ssse3),
+    lbd_entry(smooth_h, 16, 4, ssse3),  lbd_entry(smooth_h, 16, 64, ssse3),
+    lbd_entry(smooth_h, 16, 8, ssse3),  lbd_entry(smooth_h, 32, 16, ssse3),
+    lbd_entry(smooth_h, 32, 64, ssse3), lbd_entry(smooth_h, 32, 8, ssse3),
+    lbd_entry(smooth_h, 4, 16, ssse3),  lbd_entry(smooth_h, 4, 8, ssse3),
+    lbd_entry(smooth_h, 64, 16, ssse3), lbd_entry(smooth_h, 64, 32, ssse3),
+    lbd_entry(smooth_h, 8, 16, ssse3),  lbd_entry(smooth_h, 8, 32, ssse3),
+    lbd_entry(smooth_h, 8, 4, ssse3),   lbd_entry(smooth_v, 64, 64, ssse3),
+    lbd_entry(smooth_v, 32, 32, ssse3), lbd_entry(smooth_v, 16, 16, ssse3),
+    lbd_entry(smooth_v, 8, 8, ssse3),   lbd_entry(smooth_v, 4, 4, ssse3),
+    lbd_entry(smooth_v, 16, 32, ssse3), lbd_entry(smooth_v, 16, 4, ssse3),
+    lbd_entry(smooth_v, 16, 64, ssse3), lbd_entry(smooth_v, 16, 8, ssse3),
+    lbd_entry(smooth_v, 32, 16, ssse3), lbd_entry(smooth_v, 32, 64, ssse3),
+    lbd_entry(smooth_v, 32, 8, ssse3),  lbd_entry(smooth_v, 4, 16, ssse3),
+    lbd_entry(smooth_v, 4, 8, ssse3),   lbd_entry(smooth_v, 64, 16, ssse3),
+    lbd_entry(smooth_v, 64, 32, ssse3), lbd_entry(smooth_v, 8, 16, ssse3),
+    lbd_entry(smooth_v, 8, 32, ssse3),  lbd_entry(smooth_v, 8, 4, ssse3),
+    lbd_entry(smooth, 64, 64, ssse3),   lbd_entry(smooth, 32, 32, ssse3),
+    lbd_entry(smooth, 16, 16, ssse3),   lbd_entry(smooth, 8, 8, ssse3),
+    lbd_entry(smooth, 4, 4, ssse3),     lbd_entry(smooth, 16, 32, ssse3),
+    lbd_entry(smooth, 16, 4, ssse3),    lbd_entry(smooth, 16, 64, ssse3),
+    lbd_entry(smooth, 16, 8, ssse3),    lbd_entry(smooth, 32, 16, ssse3),
+    lbd_entry(smooth, 32, 64, ssse3),   lbd_entry(smooth, 32, 8, ssse3),
+    lbd_entry(smooth, 4, 16, ssse3),    lbd_entry(smooth, 4, 8, ssse3),
+    lbd_entry(smooth, 64, 16, ssse3),   lbd_entry(smooth, 64, 32, ssse3),
+    lbd_entry(smooth, 8, 16, ssse3),    lbd_entry(smooth, 8, 32, ssse3),
+    lbd_entry(smooth, 8, 4, ssse3),     lbd_entry(v, 4, 4, sse2),
+    lbd_entry(v, 8, 8, sse2),           lbd_entry(v, 16, 16, sse2),
+    lbd_entry(v, 32, 32, avx2),         lbd_entry(v, 64, 64, avx2),
+    lbd_entry(v, 16, 32, sse2),         lbd_entry(v, 16, 4, sse2),
+    lbd_entry(v, 16, 64, sse2),         lbd_entry(v, 16, 8, sse2),
+    lbd_entry(v, 32, 16, avx2),         lbd_entry(v, 32, 64, avx2),
+    lbd_entry(v, 32, 8, sse2),          lbd_entry(v, 4, 16, sse2),
+    lbd_entry(v, 4, 8, sse2),           lbd_entry(v, 64, 16, avx2),
+    lbd_entry(v, 64, 32, avx2),         lbd_entry(v, 8, 16, sse2),
+    lbd_entry(v, 8, 32, sse2),          lbd_entry(v, 8, 4, sse2),
+    lbd_entry(h, 4, 4, sse2),           lbd_entry(h, 8, 8, sse2),
+    lbd_entry(h, 16, 16, sse2),         lbd_entry(h, 32, 32, avx2),
+    lbd_entry(h, 64, 64, sse2),         lbd_entry(h, 16, 32, sse2),
+    lbd_entry(h, 16, 4, sse2),          lbd_entry(h, 16, 64, sse2),
+    lbd_entry(h, 16, 8, sse2),          lbd_entry(h, 32, 16, sse2),
+    lbd_entry(h, 32, 64, sse2),         lbd_entry(h, 32, 8, sse2),
+    lbd_entry(h, 4, 16, sse2),          lbd_entry(h, 4, 8, sse2),
+    lbd_entry(h, 64, 16, sse2),         lbd_entry(h, 64, 32, sse2),
+    lbd_entry(h, 8, 16, sse2),          lbd_entry(h, 8, 32, sse2),
+    lbd_entry(h, 8, 4, sse2),           lbd_entry(paeth, 16, 16, ssse3),
+    lbd_entry(paeth, 16, 16, avx2),     lbd_entry(paeth, 16, 32, ssse3),
+    lbd_entry(paeth, 16, 32, avx2),     lbd_entry(paeth, 16, 4, ssse3),
+    lbd_entry(paeth, 16, 64, ssse3),    lbd_entry(paeth, 16, 64, avx2),
+    lbd_entry(paeth, 16, 8, ssse3),     lbd_entry(paeth, 16, 8, avx2),
+    lbd_entry(paeth, 32, 16, ssse3),    lbd_entry(paeth, 32, 16, avx2),
+    lbd_entry(paeth, 32, 32, ssse3),    lbd_entry(paeth, 32, 32, avx2),
+    lbd_entry(paeth, 32, 64, ssse3),    lbd_entry(paeth, 32, 64, avx2),
+    lbd_entry(paeth, 32, 8, ssse3),     lbd_entry(paeth, 4, 16, ssse3),
+    lbd_entry(paeth, 4, 4, ssse3),      lbd_entry(paeth, 4, 8, ssse3),
+    lbd_entry(paeth, 64, 16, ssse3),    lbd_entry(paeth, 64, 16, avx2),
+    lbd_entry(paeth, 64, 32, ssse3),    lbd_entry(paeth, 64, 32, avx2),
+    lbd_entry(paeth, 64, 64, ssse3),    lbd_entry(paeth, 64, 64, avx2),
+    lbd_entry(paeth, 8, 16, ssse3),     lbd_entry(paeth, 8, 32, ssse3),
+    lbd_entry(paeth, 8, 4, ssse3),      lbd_entry(paeth, 8, 8, ssse3),
+};
+
+INSTANTIATE_TEST_CASE_P(intrapred, LowbdIntraPredTest,
+                        ::testing::ValuesIn(LowbdIntraPredTestVectorAsm));
+}  // namespace


### PR DESCRIPTION
1. add unit test for all the intra prediction modes except palatte
   and intrabc.
2. add unit test for upsampling and edge filter process.
3. cfl_predict_lbd_avx2 and cfl_predict_hbd_avx2 will produce
    mismatch result compared with c version.