### PR TITLE
Fix build errors in MSVC (Windows)

### DIFF
--- a/Build/linux/build.sh
+++ b/Build/linux/build.sh
@@ -11,13 +11,17 @@ function build {
     mkdir -p ../../Bin/$build_type
     cd $lowercase_build_type
 
-    cmake_env="-DBUILD_SHARED_LIBS=${enable_shared}"
-    cmake_env+=" -DCMAKE_BUILD_TYPE=${build_type}"
+    cmake_env=" -DCMAKE_BUILD_TYPE=${build_type}"
     cmake_env+=" -DCMAKE_C_COMPILER=${compiler}"
     cmake_env+=" -DCMAKE_CXX_COMPILER=${compilerxx}"
     cmake_env+=" -DCMAKE_INSTALL_PREFIX=${install_prefix}"
     cmake_env+=" -DCMAKE_ASM_NASM_COMPILER=${assembler}"
-    cmake_env+=" -DBUILD_TESTING=ON"
+    if [ "$2" = "test" ]; then
+        cmake_env+=" -DBUILD_SHARED_LIBS=ON"
+        cmake_env+=" -DBUILD_TESTING=ON"
+    else
+        cmake_env+=" -DBUILD_SHARED_LIBS=${enable_shared}"
+    fi
 
     if [ "x${target_system}" != "x" ] ; then
         cmake_env+=" -DCMAKE_SYSTEM_NAME=${target_system}"
@@ -29,7 +33,7 @@ function build {
     cmake ${verbose:+"-v"} ../../.. ${cmake_env}
 
     # Compile the Library
-    make VERBOSE=${verbose} -j ${make_threads} SvtAv1EncApp SvtAv1DecApp SvtAv1EncStatic SvtAv1DecStatic
+    make VERBOSE=${verbose} -j ${make_threads} SvtAv1EncApp SvtAv1DecApp
     if [ "$2" = "test" ]; then
         make VERBOSE=${verbose} -j ${make_threads} SvtAv1UnitTests SvtAv1ApiTests SvtAv1E2ETests TestVectors
     fi
@@ -148,7 +152,8 @@ Options:
     -c cross_prefix   - cross-tools prefix (default "${cross_prefix}")
     -s system         - Target system (default "${target_system}")
     -j threads        - Parallel make threads
-    -x                - Disable building shared library (default enabled)
+    -x                - Build static library. (default shared. Test target need shared library,
+                        this parameter has no effect with test target on. )
     -v                - Verbose output
     -h                - Show this message
     command           - clean, all, all [test], release [test],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,9 @@ endif()
 #endif()
 
 # Add Subdirectories
+if (BUILD_TESTING)
+    option(BUILD_SHARED_LIBS "Build shared libraries (DLLs)." ON)
+endif()
 add_subdirectory (Source/Lib/Common)
 add_subdirectory (Source/Lib/Encoder)
 add_subdirectory (Source/App/EncApp)

--- a/Source/App/DecApp/CMakeLists.txt
+++ b/Source/App/DecApp/CMakeLists.txt
@@ -24,16 +24,10 @@ add_executable (SvtAv1DecApp
 
 #********** SET COMPILE FLAGS************
 
-if(BUILD_SHARED_LIBS)
-    set (SvtAv1DecLib SvtAv1DecShared)
-else()
-    set (SvtAv1DecLib SvtAv1DecStatic)
-endif()
-
 if (UNIX)
     # Link the Decoder App
      target_link_libraries (SvtAv1DecApp
-        ${SvtAv1DecLib}
+        SvtAv1Dec
         pthread
         m)
 endif()
@@ -42,7 +36,7 @@ if (MSVC OR MSYS OR MINGW OR WIN32)
 
     # Link the Decoder App
     target_link_libraries (SvtAv1DecApp
-                           ${SvtAv1DecLib})
+                           SvtAv1Dec)
 endif()
 
 install(TARGETS SvtAv1DecApp RUNTIME DESTINATION bin)

--- a/Source/App/EncApp/CMakeLists.txt
+++ b/Source/App/EncApp/CMakeLists.txt
@@ -23,17 +23,10 @@ add_executable (SvtAv1EncApp
 )
 
 #********** SET COMPILE FLAGS************
-
-if(BUILD_SHARED_LIBS)
-    set (SvtAv1EncLib SvtAv1EncShared)
-else()
-    set (SvtAv1EncLib SvtAv1EncStatic)
-endif()
-
 if (UNIX)
     # Link the Encoder App
      target_link_libraries (SvtAv1EncApp
-        ${SvtAv1EncLib}
+        SvtAv1Enc
         pthread
         m)
 endif()
@@ -42,7 +35,7 @@ if (MSVC OR MSYS OR MINGW OR WIN32)
 
     # Link the Encoder App
     target_link_libraries (SvtAv1EncApp
-                           ${SvtAv1EncLib})
+                            SvtAv1Enc)
 endif()
 
 install(TARGETS SvtAv1EncApp RUNTIME DESTINATION bin)

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -1212,10 +1212,10 @@ AppExitConditionType ProcessOutputStreamBuffer(
             *total_latency += (uint64_t)headerPtr->n_tick_count;
             *max_latency = (headerPtr->n_tick_count > *max_latency) ? headerPtr->n_tick_count : *max_latency;
 
-            EbFinishTime((uint64_t*)&finishsTime, (uint64_t*)&finishuTime);
+            FinishTime((uint64_t*)&finishsTime, (uint64_t*)&finishuTime);
 
             // total execution time, inc init time
-            EbComputeOverallElapsedTime(
+            ComputeOverallElapsedTime(
                 config->performance_context.lib_start_time[0],
                 config->performance_context.lib_start_time[1],
                 finishsTime,
@@ -1223,7 +1223,7 @@ AppExitConditionType ProcessOutputStreamBuffer(
                 &config->performance_context.total_execution_time);
 
             // total encode time
-            EbComputeOverallElapsedTime(
+            ComputeOverallElapsedTime(
                 config->performance_context.encode_start_time[0],
                 config->performance_context.encode_start_time[1],
                 finishsTime,

--- a/Source/Lib/Decoder/Codec/CMakeLists.txt
+++ b/Source/Lib/Decoder/Codec/CMakeLists.txt
@@ -42,23 +42,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     list(APPEND PLATFORM_LIBS m)
 endif()
 
-if(BUILD_SHARED_LIBS)
-    # Decoder Lib Source Files
-    add_library(SvtAv1DecShared SHARED
-        ${all_files}
-        $<TARGET_OBJECTS:COMMON_CODEC>
-        $<TARGET_OBJECTS:COMMON_C_DEFAULT>
-        $<TARGET_OBJECTS:COMMON_ASM_SSE2>
-        $<TARGET_OBJECTS:COMMON_ASM_SSSE3>
-        $<TARGET_OBJECTS:COMMON_ASM_SSE4_1>
-        $<TARGET_OBJECTS:COMMON_ASM_AVX2>
-    )
-    set_target_properties(SvtAv1DecShared PROPERTIES OUTPUT_NAME SvtAv1Dec)
-    target_link_libraries(SvtAv1DecShared ${PLATFORM_LIBS})
-    install(TARGETS SvtAv1DecShared DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-endif(BUILD_SHARED_LIBS)
-
-add_library(SvtAv1DecStatic STATIC
+# Decoder Lib Source Files
+add_library(SvtAv1Dec
     ${all_files}
     $<TARGET_OBJECTS:COMMON_CODEC>
     $<TARGET_OBJECTS:COMMON_C_DEFAULT>
@@ -67,9 +52,8 @@ add_library(SvtAv1DecStatic STATIC
     $<TARGET_OBJECTS:COMMON_ASM_SSE4_1>
     $<TARGET_OBJECTS:COMMON_ASM_AVX2>
 )
-set_target_properties(SvtAv1DecStatic PROPERTIES OUTPUT_NAME SvtAv1Dec)
-target_link_libraries(SvtAv1DecStatic ${PLATFORM_LIBS})
-install(TARGETS SvtAv1DecStatic DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+target_link_libraries(SvtAv1Dec ${PLATFORM_LIBS})
+install(TARGETS SvtAv1Dec DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
 if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)
     set(CMAKE_INSTALL_INCLUDEDIR "include/svt-av1")

--- a/Source/Lib/Encoder/Codec/CMakeLists.txt
+++ b/Source/Lib/Encoder/Codec/CMakeLists.txt
@@ -42,24 +42,9 @@ file(GLOB all_files
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     list(APPEND PLATFORM_LIBS m)
 endif()
-
-if(BUILD_SHARED_LIBS)
-    # Encoder Lib Source Files
-    add_library(SvtAv1EncShared SHARED
-        ${all_files}
-        $<TARGET_OBJECTS:COMMON_CODEC>
-        $<TARGET_OBJECTS:COMMON_C_DEFAULT>
-        $<TARGET_OBJECTS:COMMON_ASM_SSE2>
-        $<TARGET_OBJECTS:COMMON_ASM_SSSE3>
-        $<TARGET_OBJECTS:COMMON_ASM_SSE4_1>
-        $<TARGET_OBJECTS:COMMON_ASM_AVX2>
-    )
-    set_target_properties(SvtAv1EncShared PROPERTIES OUTPUT_NAME SvtAv1EncShared)
-    target_link_libraries(SvtAv1EncShared ${PLATFORM_LIBS})
-    install(TARGETS SvtAv1EncShared DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-endif(BUILD_SHARED_LIBS)
-
-add_library(SvtAv1EncStatic STATIC
+message(STATUS "BUILD_SHARED_LIBS : " ${BUILD_SHARED_LIBS})
+# Encoder Lib Source Files
+add_library(SvtAv1Enc
     ${all_files}
     $<TARGET_OBJECTS:COMMON_CODEC>
     $<TARGET_OBJECTS:COMMON_C_DEFAULT>
@@ -68,9 +53,8 @@ add_library(SvtAv1EncStatic STATIC
     $<TARGET_OBJECTS:COMMON_ASM_SSE4_1>
     $<TARGET_OBJECTS:COMMON_ASM_AVX2>
 )
-set_target_properties(SvtAv1EncStatic PROPERTIES OUTPUT_NAME SvtAv1Enc)
-target_link_libraries(SvtAv1EncStatic ${PLATFORM_LIBS})
-install(TARGETS SvtAv1EncStatic DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+target_link_libraries(SvtAv1Enc ${PLATFORM_LIBS})
+install(TARGETS SvtAv1Enc DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
 if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)
     set(CMAKE_INSTALL_INCLUDEDIR "include/svt-av1")

--- a/Source/Lib/Encoder/Codec/CMakeLists.txt
+++ b/Source/Lib/Encoder/Codec/CMakeLists.txt
@@ -54,7 +54,7 @@ if(BUILD_SHARED_LIBS)
         $<TARGET_OBJECTS:COMMON_ASM_SSE4_1>
         $<TARGET_OBJECTS:COMMON_ASM_AVX2>
     )
-    set_target_properties(SvtAv1EncShared PROPERTIES OUTPUT_NAME SvtAv1Enc)
+    set_target_properties(SvtAv1EncShared PROPERTIES OUTPUT_NAME SvtAv1EncShared)
     target_link_libraries(SvtAv1EncShared ${PLATFORM_LIBS})
     install(TARGETS SvtAv1EncShared DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 endif(BUILD_SHARED_LIBS)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ install:
     - git submodule update --init
     - appveyor DownloadFile http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe -FileName yasm.exe
     - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%
-    - cmake . -G "Visual Studio 16 2019" -A x64 -DCMAKE_ASM_NASM_COMPILER="yasm.exe"
+    - cmake . -G "Visual Studio 16 2019" -A x64 -DCMAKE_ASM_NASM_COMPILER="yasm.exe" -DBUILD_TESTING=ON
 
 build:
   project: svt-av1.sln

--- a/test/api_test/CMakeLists.txt
+++ b/test/api_test/CMakeLists.txt
@@ -37,12 +37,6 @@ file(GLOB all_files
     "*.h"
     "*.cc")
 
-if(BUILD_SHARED_LIBS)
-    set (SvtAv1EncLib SvtAv1EncShared)
-else()
-    set (SvtAv1EncLib SvtAv1EncStatic)
-endif()
-
 if (UNIX)
 
   # App Source Files
@@ -51,7 +45,7 @@ if (UNIX)
 
     # Link the Encoder App
      target_link_libraries (SvtAv1ApiTests
-        ${SvtAv1EncLib}
+        SvtAv1Enc
         gtest_all
         pthread
         m)
@@ -59,7 +53,8 @@ if (UNIX)
 endif(UNIX)
 
 if (MSVC OR MSYS OR MINGW OR WIN32)
-    set (lib_list ${SvtAv1EncLib} gtest_all)
+
+    set (lib_list SvtAv1Enc gtest_all)
 
     cxx_executable_with_flags(SvtAv1ApiTests "${cxx_default}"
       "${lib_list}" ${all_files})

--- a/test/api_test/CMakeLists.txt
+++ b/test/api_test/CMakeLists.txt
@@ -59,8 +59,7 @@ if (UNIX)
 endif(UNIX)
 
 if (MSVC OR MSYS OR MINGW OR WIN32)
-
-    set (lib_list SvtAv1Enc gtest_all)
+    set (lib_list ${SvtAv1EncLib} gtest_all)
 
     cxx_executable_with_flags(SvtAv1ApiTests "${cxx_default}"
       "${lib_list}" ${all_files})

--- a/test/e2e_test/CMakeLists.txt
+++ b/test/e2e_test/CMakeLists.txt
@@ -58,12 +58,6 @@ file(GLOB all_files
     "../../Source/App/EncApp/EbAppInputy4m.c"
     "../../Source/App/EncApp/EbAppString.c")
 
-if(BUILD_SHARED_LIBS)
-    set (SvtAv1EncLib SvtAv1EncShared)
-else()
-    set (SvtAv1EncLib SvtAv1EncStatic)
-endif()
-
 if (UNIX)
 
   # App Source Files
@@ -84,7 +78,7 @@ if (UNIX)
     # Link the Encoder App
      target_link_libraries (SvtAv1E2ETests
         aom
-        ${SvtAv1EncLib}
+        SvtAv1Enc
         gtest_all
         pthread
         m)
@@ -93,7 +87,7 @@ endif(UNIX)
 
 if (MSVC OR MSYS OR MINGW OR WIN32)
 
-    set (lib_list ${SvtAv1EncLib} gtest_all)
+    set (lib_list SvtAv1Enc gtest_all)
 
     cxx_executable_with_flags(SvtAv1E2ETests "${cxx_default}"
       "${lib_list}" ${all_files})


### PR DESCRIPTION
1. Rename SvtAv1Enc output to "SvtAv1EncShared" to avoid name conflict with static library build.
2. Fix build break with two funxtions "EbFinishTime" and "EbComputeOverallElapsedTime" can not be found.