### PR TITLE
Remove build warning in unit test

### DIFF
--- a/test/BitstreamWriterTest.cc
+++ b/test/BitstreamWriterTest.cc
@@ -15,6 +15,9 @@
 #include <stdlib.h>
 #include <random>
 #include "EbCabacContextModel.h"
+#if defined(CHAR_BIT)
+#undef CHAR_BIT  // defined in clang/9.1.0/include/limits.h
+#endif
 #include "EbDecBitReader.h"
 #include "gtest/gtest.h"
 #include "random.h"
@@ -120,25 +123,25 @@ class BitstreamWriterTest : public ::testing::Test {
         case 3:
             // uniform distribution between 0 ~ 255
             for (int i = 0; i < total_probas; ++i)
-                probas[i] = normal_probs_->random();
+                probas[i] = (uint8_t)normal_probs_->random();
             break;
         case 4:
             // low probability
             for (int i = 0; i < total_probas; ++i)
-                probas[i] = low_probs_->random();
+                probas[i] = (uint8_t)low_probs_->random();
             break;
         case 5:
             // high probability
             for (int i = 0; i < total_probas; ++i)
-                probas[i] = 255 - low_probs_->random();
+                probas[i] = 255 - (uint8_t)low_probs_->random();
             break;
         case 6:
         default:
             // mix high and low probability
             for (int i = 0; i < total_probas; ++i) {
                 bool flip = flip_dist(gen_);
-                probas[i] =
-                    flip ? low_probs_->random() : 255 - low_probs_->random();
+                probas[i] = flip ? (uint8_t)low_probs_->random()
+                                 : 255 - (uint8_t)low_probs_->random();
             }
             break;
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,8 +28,8 @@ include_directories(${PROJECT_SOURCE_DIR}/test/
 include(../third_party/googletest/cmake/internal_utils.cmake)
 
 if(MSVC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4 -D_ALLOW_KEYWORD_MACROS")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 -D_ALLOW_KEYWORD_MACROS")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_ALLOW_KEYWORD_MACROS")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_ALLOW_KEYWORD_MACROS")
 endif()
 
 # When other libraries are using a shared version of runtime libraries,

--- a/test/EbUnitTestUtility.c
+++ b/test/EbUnitTestUtility.c
@@ -438,10 +438,10 @@ void eb_unit_test_log_ptrdiff(const char *const nameBuf,
     printf("%16s = ", nameBuf);
 
     if (sizeBuf == 1)
-        printf("%" PRIu64 "\n", buf[0]);
+        printf("%td\n", buf[0]);
     else {
         for (uint32_t i = 0; i < sizeBuf; i++) {
-            printf("%10" PRIu64 ",", buf[i]);
+            printf("%10td,", buf[i]);
             if (!((i + 1) % 32))
                 printf("\n  ");
         }

--- a/test/FwdTxfm1dTest.cc
+++ b/test/FwdTxfm1dTest.cc
@@ -71,6 +71,25 @@ class AV1FwdTxfm1dTest : public ::testing::TestWithParam<FwdTxfm1dParam> {
         txfm_size_ = get_txfm1d_size(txfm_type_);
     }
 
+    void SetUp() override {
+        input_test_ = reinterpret_cast<int32_t *>(
+            aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
+        output_test_ = reinterpret_cast<int32_t *>(
+            aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
+        input_ref_ = reinterpret_cast<double *>(
+            aom_memalign(32, MAX_TX_SIZE * sizeof(double)));
+        output_ref_ = reinterpret_cast<double *>(
+            aom_memalign(32, MAX_TX_SIZE * sizeof(double)));
+    }
+
+    void TearDown() override {
+        aom_free(input_test_);
+        aom_free(output_test_);
+        aom_free(input_ref_);
+        aom_free(output_ref_);
+        aom_clear_system_state();
+    }
+
     void run_fwd_accuracy_check() {
         const int bd = 10;
         // The input is residual, and it should be signed bd+1 bits
@@ -109,10 +128,10 @@ class AV1FwdTxfm1dTest : public ::testing::TestWithParam<FwdTxfm1dParam> {
     const int max_error_;      /**< max error allowed */
     int txfm_size_;            /**< transform size, max transform is DCT64 */
     const TxfmType txfm_type_; /**< tx type, including dct, iadst, idtx */
-    DECLARE_ALIGNED(32, int32_t, input_test_[MAX_TX_SIZE]);
-    DECLARE_ALIGNED(32, int32_t, output_test_[MAX_TX_SIZE]);
-    DECLARE_ALIGNED(32, double, input_ref_[MAX_TX_SIZE]);
-    DECLARE_ALIGNED(32, double, output_ref_[MAX_TX_SIZE]);
+    int32_t *input_test_;
+    int32_t *output_test_;
+    double *input_ref_;
+    double *output_ref_;
 };
 
 TEST_P(AV1FwdTxfm1dTest, run_fwd_accuracy_check) {

--- a/test/FwdTxfm2dAsmTest.cc
+++ b/test/FwdTxfm2dAsmTest.cc
@@ -114,8 +114,8 @@ class FwdTxfm2dAsmTest : public ::testing::TestWithParam<FwdTxfm2dAsmParam> {
             for (int k = 0; k < loops; k++) {
                 populate_with_random();
 
-                ref_func(input_, output_ref_, stride_, type, bd_);
-                test_func(input_, output_test_, stride_, type, bd_);
+                ref_func(input_, output_ref_, stride_, type, (uint8_t)bd_);
+                test_func(input_, output_test_, stride_, type, (uint8_t)bd_);
 
                 for (int i = 0; i < height_; i++)
                     for (int j = 0; j < width_; j++)
@@ -132,7 +132,7 @@ class FwdTxfm2dAsmTest : public ::testing::TestWithParam<FwdTxfm2dAsmParam> {
     void populate_with_random() {
         for (int i = 0; i < height_; i++) {
             for (int j = 0; j < width_; j++) {
-                input_[i * stride_ + j] = rnd_->random();
+                input_[i * stride_ + j] = (int16_t)rnd_->random();
             }
         }
 

--- a/test/FwdTxfm2dTest.cc
+++ b/test/FwdTxfm2dTest.cc
@@ -34,7 +34,6 @@
 #include "random.h"
 #include "TxfmRef.h"
 #include "util.h"
-
 #include "TxfmCommon.h"
 
 using svt_av1_test_reference::get_scale_factor;
@@ -72,6 +71,25 @@ class AV1FwdTxfm2dTest : public ::testing::TestWithParam<FwdTxfm2dParam> {
         Av1TransformConfig(txfm_type_, txfm_size_, &cfg_);
     }
 
+    void SetUp() override {
+        input_test_ = reinterpret_cast<int16_t *>(
+            aom_memalign(32, MAX_TX_SQUARE * sizeof(int16_t)));
+        output_test_ = reinterpret_cast<int32_t *>(
+            aom_memalign(32, MAX_TX_SQUARE * sizeof(int32_t)));
+        input_ref_ = reinterpret_cast<double *>(
+            aom_memalign(32, MAX_TX_SQUARE * sizeof(double)));
+        output_ref_ = reinterpret_cast<double *>(
+            aom_memalign(32, MAX_TX_SQUARE * sizeof(double)));
+    }
+
+    void TearDown() override {
+        aom_free(input_test_);
+        aom_free(output_test_);
+        aom_free(input_ref_);
+        aom_free(output_ref_);
+        aom_clear_system_state();
+    }
+
   protected:
     void run_fwd_accuracy_check() {
         const int bd = 10;
@@ -85,7 +103,7 @@ class AV1FwdTxfm2dTest : public ::testing::TestWithParam<FwdTxfm2dParam> {
         for (int ti = 0; ti < count_test_block; ++ti) {
             // prepare random test data
             for (int ni = 0; ni < block_size; ++ni) {
-                input_test_[ni] = rnd.random();
+                input_test_[ni] = (int16_t)rnd.random();
                 input_ref_[ni] = static_cast<double>(input_test_[ni]);
                 output_ref_[ni] = 0;
                 output_test_[ni] = 255;
@@ -213,10 +231,10 @@ class AV1FwdTxfm2dTest : public ::testing::TestWithParam<FwdTxfm2dParam> {
     const TxType txfm_type_;
     double scale_factor_;
     Txfm2DFlipCfg cfg_;
-    DECLARE_ALIGNED(32, int16_t, input_test_[MAX_TX_SQUARE]);
-    DECLARE_ALIGNED(32, int32_t, output_test_[MAX_TX_SQUARE]);
-    DECLARE_ALIGNED(32, double, input_ref_[MAX_TX_SQUARE]);
-    DECLARE_ALIGNED(32, double, output_ref_[MAX_TX_SQUARE]);
+    int16_t *input_test_;
+    int32_t *output_test_;
+    double *input_ref_;
+    double *output_ref_;
 };
 
 TEST_P(AV1FwdTxfm2dTest, run_fwd_accuracy_check) {
@@ -254,7 +272,7 @@ static std::vector<FwdTxfm2dParam> gen_txfm_2d_params() {
             const TxSize txfm_size = static_cast<TxSize>(s);
             if (is_txfm_allowed(txfm_type, txfm_size)) {
                 param_vec.push_back(
-                    FwdTxfm2dParam(txfm_size, txfm_type, max_error));
+                    FwdTxfm2dParam(txfm_size, txfm_type, (int)max_error));
             }
         }
     }

--- a/test/InvTxfm1dTest.cc
+++ b/test/InvTxfm1dTest.cc
@@ -70,6 +70,22 @@ class AV1InvTxfm1dTest : public ::testing::TestWithParam<InvTxfm1dParam> {
         txfm_size_ = get_txfm1d_size(txfm_type_);
     }
 
+    void SetUp() override {
+        input_ = reinterpret_cast<int32_t *>(
+            aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
+        output_ = reinterpret_cast<int32_t *>(
+            aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
+        inv_output_ = reinterpret_cast<int32_t *>(
+            aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
+    }
+
+    void TearDown() override {
+        aom_free(input_);
+        aom_free(output_);
+        aom_free(inv_output_);
+        aom_clear_system_state();
+    }
+
     void run_inv_accuracy_check() {
         SVTRandom rnd(10, true);
         const int count_test_block = 5000;
@@ -105,9 +121,9 @@ class AV1InvTxfm1dTest : public ::testing::TestWithParam<InvTxfm1dParam> {
     const int max_error_;      /**< max error allowed */
     int txfm_size_;            /**< transform size, max transform is DCT64 */
     const TxfmType txfm_type_; /**< tx type, including dct, iadst, idtx */
-    DECLARE_ALIGNED(32, int32_t, input_[MAX_TX_SIZE]);
-    DECLARE_ALIGNED(32, int32_t, output_[MAX_TX_SIZE]);
-    DECLARE_ALIGNED(32, int32_t, inv_output_[MAX_TX_SIZE]);
+    int32_t *input_;
+    int32_t *output_;
+    int32_t *inv_output_;
 };
 
 TEST_P(AV1InvTxfm1dTest, run_inv_accuracy_check) {

--- a/test/InvTxfm2dAsmTest.cc
+++ b/test/InvTxfm2dAsmTest.cc
@@ -178,6 +178,28 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<int> {
         aom_clear_system_state();
     }
 
+    void SetUp() override {
+        pixel_input_ = reinterpret_cast<int16_t *>(
+            aom_memalign(32, MAX_TX_SQUARE * sizeof(int16_t)));
+        input_ = reinterpret_cast<int32_t *>(
+            aom_memalign(32, MAX_TX_SQUARE * sizeof(int32_t)));
+        output_test_ = reinterpret_cast<uint16_t *>(
+            aom_memalign(32, MAX_TX_SQUARE * sizeof(uint16_t)));
+        output_ref_ = reinterpret_cast<uint16_t *>(
+            aom_memalign(32, MAX_TX_SQUARE * sizeof(uint16_t)));
+        lowbd_output_test_ = reinterpret_cast<uint8_t *>(
+            aom_memalign(32, MAX_TX_SQUARE * sizeof(uint8_t)));
+    }
+
+    void TearDown() override {
+        aom_free(pixel_input_);
+        aom_free(input_);
+        aom_free(output_test_);
+        aom_free(output_ref_);
+        aom_free(lowbd_output_test_);
+        aom_clear_system_state();
+    }
+
     void run_sqr_txfm_match_test(const TxSize tx_size, int asm_type) {
         const int width = tx_size_wide[tx_size];
         const int height = tx_size_high[tx_size];
@@ -401,8 +423,8 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<int> {
         for (int idx = 0; idx < num_htf_sizes; ++idx) {
             const TxSize tx_size = htf_tx_size[idx];
 
-            eb_buf_random_s32(input_, sizeof(input_) / sizeof(*input_));
-            memcpy(input, input_, sizeof(input_));
+            eb_buf_random_s32(input_, MAX_TX_SQUARE);
+            memcpy(input, input_, MAX_TX_SQUARE * sizeof(int32_t));
 
             const uint64_t energy_ref = htf_ref_funcs[idx](input_);
             const uint64_t energy_asm = htf_asm_funcs[idx](input);
@@ -449,8 +471,8 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<int> {
             const uint64_t num_loop = 10000000;
             uint64_t energy_ref, energy_asm;
 
-            eb_buf_random_s32(input_, sizeof(input_) / sizeof(*input_));
-            memcpy(input, input_, sizeof(input_));
+            eb_buf_random_s32(input_, MAX_TX_SQUARE);
+            memcpy(input, input_, MAX_TX_SQUARE * sizeof(int32_t));
 
             EbStartTime(&start_time_seconds, &start_time_useconds);
 
@@ -537,11 +559,11 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<int> {
             av1_fwd_txfm2d_64x16_c,
         };
 
-        memset(output_ref_, 0, sizeof(output_ref_));
-        memset(output_test_, 0, sizeof(output_test_));
-        memset(input_, 0, sizeof(input_));
-        memset(pixel_input_, 0, sizeof(pixel_input_));
-        memset(lowbd_output_test_, 0, sizeof(lowbd_output_test_));
+        memset(output_ref_, 0, MAX_TX_SQUARE * sizeof(uint16_t));
+        memset(output_test_, 0, MAX_TX_SQUARE * sizeof(uint16_t));
+        memset(input_, 0, MAX_TX_SQUARE * sizeof(int32_t));
+        memset(pixel_input_, 0, MAX_TX_SQUARE * sizeof(int16_t));
+        memset(lowbd_output_test_, 0, MAX_TX_SQUARE * sizeof(uint8_t));
         for (int i = 0; i < height; i++) {
             for (int j = 0; j < width; j++) {
                 pixel_input_[i * stride_ + j] =
@@ -571,11 +593,11 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<int> {
 
     const int bd_; /**< input param 8bit or 10bit */
     static const int stride_ = MAX_TX_SIZE;
-    DECLARE_ALIGNED(32, int16_t, pixel_input_[MAX_TX_SQUARE]);
-    DECLARE_ALIGNED(32, int32_t, input_[MAX_TX_SQUARE]);
-    DECLARE_ALIGNED(32, uint16_t, output_test_[MAX_TX_SQUARE]);
-    DECLARE_ALIGNED(32, uint16_t, output_ref_[MAX_TX_SQUARE]);
-    DECLARE_ALIGNED(32, uint8_t, lowbd_output_test_[MAX_TX_SQUARE]);
+    int16_t *pixel_input_;
+    int32_t *input_;
+    uint16_t *output_test_;
+    uint16_t *output_ref_;
+    uint8_t *lowbd_output_test_;
 };
 
 TEST_P(InvTxfm2dAsmTest, sqr_txfm_match_test) {

--- a/test/QuantAsmTest.cc
+++ b/test/QuantAsmTest.cc
@@ -98,6 +98,28 @@ class QuantizeBTest : public ::testing::TestWithParam<QuantizeParam> {
         aom_clear_system_state();
     }
 
+    void SetUp() override {
+        coeff_in_ = reinterpret_cast<TranLow *>(
+            aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
+        qcoeff_ref_ = reinterpret_cast<TranLow *>(
+            aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
+        dqcoeff_ref_ = reinterpret_cast<TranLow *>(
+            aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
+        qcoeff_test_ = reinterpret_cast<TranLow *>(
+            aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
+        dqcoeff_test_ = reinterpret_cast<TranLow *>(
+            aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
+    }
+
+    void TearDown() override {
+        aom_free(coeff_in_);
+        aom_free(qcoeff_ref_);
+        aom_free(dqcoeff_ref_);
+        aom_free(qcoeff_test_);
+        aom_free(dqcoeff_test_);
+        aom_clear_system_state();
+    }
+
     /*
      * @brief setup reference and target function ptrs
      * @see setup_rtcd_internal() in aom_dsp_rtcd.h
@@ -141,10 +163,10 @@ class QuantizeBTest : public ::testing::TestWithParam<QuantizeParam> {
         const int16_t *quant_shift = qtab_quants_.y_quant_shift[q];
         const int16_t *dequant = qtab_deq_.y_dequant_QTX[q];
 
-        memset(qcoeff_ref_, 0, sizeof(qcoeff_ref_));
-        memset(dqcoeff_ref_, 0, sizeof(dqcoeff_ref_));
-        memset(qcoeff_test_, 0, sizeof(qcoeff_test_));
-        memset(dqcoeff_test_, 0, sizeof(dqcoeff_test_));
+        memset(qcoeff_ref_, 0, MAX_TX_SQUARE * sizeof(TranLow));
+        memset(dqcoeff_ref_, 0, MAX_TX_SQUARE * sizeof(TranLow));
+        memset(qcoeff_test_, 0, MAX_TX_SQUARE * sizeof(TranLow));
+        memset(dqcoeff_test_, 0, MAX_TX_SQUARE * sizeof(TranLow));
 
         quant_ref_(coeff_in_,
                    n_coeffs_,
@@ -214,11 +236,11 @@ class QuantizeBTest : public ::testing::TestWithParam<QuantizeParam> {
     uint16_t eob_ref_;        /**< output ref eob */
     uint16_t eob_test_;       /**< output test eob */
 
-    DECLARE_ALIGNED(32, TranLow, coeff_in_[MAX_TX_SQUARE]);
-    DECLARE_ALIGNED(32, TranLow, qcoeff_ref_[MAX_TX_SQUARE]);
-    DECLARE_ALIGNED(32, TranLow, dqcoeff_ref_[MAX_TX_SQUARE]);
-    DECLARE_ALIGNED(32, TranLow, qcoeff_test_[MAX_TX_SQUARE]);
-    DECLARE_ALIGNED(32, TranLow, dqcoeff_test_[MAX_TX_SQUARE]);
+    TranLow *coeff_in_;
+    TranLow *qcoeff_ref_;
+    TranLow *dqcoeff_ref_;
+    TranLow *qcoeff_test_;
+    TranLow *dqcoeff_test_;
 };
 
 /**

--- a/test/convolve_2d_test.cc
+++ b/test/convolve_2d_test.cc
@@ -27,13 +27,17 @@
  * @author Cidana-Wenyao
  *
  ******************************************************************************/
-#include "stdlib.h"
+#include <stdlib.h>
 #include "gtest/gtest.h"
 #include "EbDefinitions.h"
 #include "random.h"
 #include "util.h"
+#include "EbUtility.h"
 #include "convolve.h"
 #include "convolve_2d_funcs.h"
+#if defined(_MSC_VER)
+#pragma warning(suppress : 4324)
+#endif
 
 const int kMaxSize = 128 + 32;  // padding
 using svt_av1_test_tool::SVTRandom;
@@ -85,16 +89,20 @@ class AV1Convolve2DTest : public ::testing::TestWithParam<Convolve2DParam> {
     // make the address algined to 32.
     void SetUp() override {
         conv_buf_ref_ = reinterpret_cast<ConvBufType *>(
-            ((intptr_t)conv_ref_data_ + 31) & ~31);
+            aom_memalign(32, MAX_SB_SQUARE * sizeof(ConvBufType)));
         conv_buf_tst_ = reinterpret_cast<ConvBufType *>(
-            ((intptr_t)conv_tst_data_ + 31) & ~31);
-        output_ref_ =
-            reinterpret_cast<Sample *>(((intptr_t)output_ref_data_ + 31) & ~31);
-        output_tst_ =
-            reinterpret_cast<Sample *>(((intptr_t)output_tst_data_ + 31) & ~31);
+            aom_memalign(32, MAX_SB_SQUARE * sizeof(ConvBufType)));
+        output_ref_ = reinterpret_cast<Sample *>(
+            aom_memalign(32, MAX_SB_SQUARE * sizeof(Sample)));
+        output_tst_ = reinterpret_cast<Sample *>(
+            aom_memalign(32, MAX_SB_SQUARE * sizeof(Sample)));
     }
 
     void TearDown() override {
+        aom_free(conv_buf_ref_);
+        aom_free(conv_buf_tst_);
+        aom_free(output_ref_);
+        aom_free(output_tst_);
         aom_clear_system_state();
     }
 
@@ -188,7 +196,7 @@ class AV1Convolve2DTest : public ::testing::TestWithParam<Convolve2DParam> {
 
         for (int i = 0; i < h; ++i)
             for (int j = 0; j < w; ++j)
-                input[i * w + j] = rnd_.random();
+                input[i * w + j] = (Sample)rnd_.random();
 
         for (int i = 0; i < MAX_SB_SQUARE; ++i) {
             conv_buf_ref_[i] = conv_buf_tst_[i] = 0;
@@ -318,10 +326,6 @@ class AV1Convolve2DTest : public ::testing::TestWithParam<Convolve2DParam> {
     ConvBufType *conv_buf_tst_;  // aligned address
     Sample *output_ref_;         // aligned address
     Sample *output_tst_;         // aligned address
-    DECLARE_ALIGNED(32, ConvBufType, conv_ref_data_[MAX_SB_SQUARE + 32]);
-    DECLARE_ALIGNED(32, ConvBufType, conv_tst_data_[MAX_SB_SQUARE + 32]);
-    DECLARE_ALIGNED(32, Sample, output_ref_data_[MAX_SB_SQUARE + 32]);
-    DECLARE_ALIGNED(32, Sample, output_tst_data_[MAX_SB_SQUARE + 32]);
 };
 
 ::testing::internal::ParamGenerator<Convolve2DParam> BuildParams(int has_subx,

--- a/test/e2e_test/CMakeLists.txt
+++ b/test/e2e_test/CMakeLists.txt
@@ -41,6 +41,10 @@ set(lib_list
     #SDL2.lib
     aom)
 
+if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS")
+endif()
+
 if(UNIX)
   # App Source Files
     add_executable(SvtAv1E2ETests

--- a/test/e2e_test/E2eTestVectors.h
+++ b/test/e2e_test/E2eTestVectors.h
@@ -17,6 +17,7 @@
 
 #include <map>
 #include "VideoSource.h"
+#include "EbDefinitions.h"
 
 /** @defgroup svt_av1_e2e_test_vector Test vectors for E2E test
  *  Defines the test vectors of E2E test, with file-type, width, height and
@@ -40,12 +41,11 @@ typedef std::tuple<std::string,      /**< file name */
                    VideoColorFormat, /**< color format */
                    uint32_t,         /**< width */
                    uint32_t,         /**< height */
-                   uint8_t,          /**< bit depth */
+                   uint32_t,         /**< bit depth */
                    bool,             /**< compressed 2-bit in 10-bit frame */
                    uint32_t,         /**< start read position in frame */
                    uint32_t> /**< frames to test, (0) means full-frames*/
     TestVideoVector;
-
 const std::vector<TestVideoVector> default_test_vectors = {
     std::make_tuple("park_joy_90p_8_420.y4m", Y4M_VIDEO_FILE, IMG_FMT_420, 160,
                     90, 8, 0, 0, 0),
@@ -126,7 +126,8 @@ static inline const std::vector<EncTestSetting> generate_vector_from_config(
         svt_av1_video_source::VideoFileSource::get_vector_dir();
     cfg_fn = cfg_fn + '/' + config_file;
 
-    FILE* file_handle = fopen(cfg_fn.c_str(), "rt");
+    FILE* file_handle;
+    FOPEN(file_handle, cfg_fn.c_str(), "rt");
     if (file_handle != nullptr) {
         char line[1024] = {0};
         while (fgets(line, 1024, file_handle) != nullptr) {
@@ -168,7 +169,7 @@ static inline const std::vector<EncTestSetting> generate_vector_from_config(
                                              color_fmt_type,
                                              w,
                                              h,
-                                             bit_depth,
+                                             (uint8_t)bit_depth,
                                              compressed_10bit,
                                              start_frame,
                                              frame_count));

--- a/test/e2e_test/FrameQueue.cc
+++ b/test/e2e_test/FrameQueue.cc
@@ -38,12 +38,11 @@ bool FrameQueue::compare(FrameQueue *other) {
                other->get_frame_count());
         return false;
     }
-
     bool is_same = true;
-    for (size_t i = 0; i < frame_count_; i++) {
+    for (uint32_t i = 0; i < frame_count_; i++) {
         VideoFrame *frame = take_frame_inorder(i);
         VideoFrame *other_frame = other->take_frame_inorder(i);
-        bool is_same = compare_image(frame, other_frame);
+        is_same = compare_image(frame, other_frame);
         if (!is_same) {
             printf("ref_frame(%u) compare failed!!\n",
                    (uint32_t)frame->timestamp);
@@ -160,7 +159,7 @@ class FrameQueueBufferSort_ASC {
   public:
     bool operator()(VideoFrame *a, VideoFrame *b) const {
         return a->timestamp < b->timestamp;
-    };
+    }
 };
 
 class FrameQueueBuffer : public FrameQueue {

--- a/test/e2e_test/ParseUtil.cc
+++ b/test/e2e_test/ParseUtil.cc
@@ -462,7 +462,7 @@ AomCodecErr read_obu_header(struct aom_read_bit_buffer *rb, int is_annexb,
 // sequence header parser
 static int read_bitstream_level(BitstreamLevel *bl,
                                 struct aom_read_bit_buffer *rb) {
-    const uint8_t seq_level_idx = aom_rb_read_literal(rb, LEVEL_BITS);
+    const uint8_t seq_level_idx = (uint8_t)aom_rb_read_literal(rb, LEVEL_BITS);
     if (!is_valid_seq_level_idx(seq_level_idx))
         return 0;
     bl->major = (seq_level_idx >> LEVEL_MINOR_BITS) + LEVEL_MAJOR_MIN;
@@ -854,7 +854,7 @@ uint32_t read_sequence_header_obu(SequenceHeader *seq_params,
             // This is the seq_level_idx[i] > 7 check in the spec. seq_level_idx
             // 7 is equivalent to level 3.3.
             if (seq_params->level[i].major > 3)
-                seq_params->tier[i] = aom_rb_read_bit(rb);
+                seq_params->tier[i] = (uint8_t)aom_rb_read_bit(rb);
             else
                 seq_params->tier[i] = 0;
             if (seq_params->decoder_model_info_present_flag) {
@@ -950,7 +950,9 @@ uint32_t read_sequence_header_obu(SequenceHeader *seq_params,
 }
 
 int parse_sequence_header_from_file(const char *ivf_file) {
-    FILE *f = fopen(ivf_file, "rb");
+    FILE *f;
+    FOPEN(f, ivf_file, "rb");
+
     struct AvxInputContext input_ctx = {ivf_file, f, 0, 0, 0, {0, 0}};
     if (!file_is_ivf(&input_ctx)) {
         printf("File is NOT valid ivf\n");
@@ -1003,11 +1005,11 @@ int parse_sequence_header_from_file(const char *ivf_file) {
 
                 // check the ou type and parse sequence header
                 if (ou.type == OBU_SEQUENCE_HEADER) {
-                    struct aom_read_bit_buffer rb = {
+                    struct aom_read_bit_buffer rb1 = {
                         frame_buf, frame_buf + frame_sz, 0, NULL, NULL};
                     SequenceHeader sqs_headers;
                     memset(&sqs_headers, 0, sizeof(sqs_headers));
-                    if (read_sequence_header_obu(&sqs_headers, &rb) == 0) {
+                    if (read_sequence_header_obu(&sqs_headers, &rb1) == 0) {
                         printf("read seqence header fail\n");
                     }
                 }
@@ -1055,11 +1057,11 @@ void SequenceHeaderParser::input_obu_data(const uint8_t *obu_data,
             frame_sz -= value_len;
             if (ou.type == OBU_SEQUENCE_HEADER) {
                 // check the ou type and parse sequence header
-                struct aom_read_bit_buffer rb = {
+                struct aom_read_bit_buffer rb1 = {
                     frame_buf, frame_buf + frame_sz, 0, NULL, NULL};
                 SequenceHeader sqs_headers;
                 memset(&sqs_headers, 0, sizeof(sqs_headers));
-                ASSERT_NE(read_sequence_header_obu(&sqs_headers, &rb), 0u)
+                ASSERT_NE(read_sequence_header_obu(&sqs_headers, &rb1), 0u)
                     << "read seqence header fail";
                 profile_ = sqs_headers.profile;
                 switch (sqs_headers.sb_size) {
@@ -1098,7 +1100,7 @@ void SequenceHeaderParser::input_obu_data(const uint8_t *obu_data,
                     sqs_headers.enable_restoration;
             }
             frame_buf += u64_payload_length;
-            frame_sz -= u64_payload_length;
+            frame_sz -= (uint32_t)u64_payload_length;
         }
     } while (err == 0 && frame_sz > 0);
 }

--- a/test/e2e_test/RefDecoder.cc
+++ b/test/e2e_test/RefDecoder.cc
@@ -19,6 +19,12 @@
 #include "gtest/gtest.h"
 #include "RefDecoder.h"
 #include "ParseUtil.h"
+#ifdef _MSC_VER
+// The given function is local and not referenced in the body of the module;
+// therefore, the function is dead code.
+// Disable it since the aom_codec_control_xxx is not used.
+#pragma warning(disable : 4505)
+#endif
 
 /** from aom/common/blockd.h */
 typedef enum {

--- a/test/e2e_test/SvtAv1E2EFramework.cc
+++ b/test/e2e_test/SvtAv1E2EFramework.cc
@@ -41,14 +41,14 @@ VideoSource *SvtAv1E2ETestFramework::prepare_video_src(
                                        std::get<2>(vector),
                                        std::get<3>(vector),
                                        std::get<4>(vector),
-                                       std::get<5>(vector));
+                                       (uint8_t)std::get<5>(vector));
         break;
     case Y4M_VIDEO_FILE:
         video_src = new Y4MVideoSource(std::get<0>(vector),
                                        std::get<2>(vector),
                                        std::get<3>(vector),
                                        std::get<4>(vector),
-                                       std::get<5>(vector),
+                                       (uint8_t)std::get<5>(vector),
                                        std::get<6>(vector));
         break;
     default: assert(0); break;
@@ -418,7 +418,8 @@ void SvtAv1E2ETestFramework::run_encode_process() {
                 EbBufferHeaderType *enc_out = nullptr;
                 {
                     TimeAutoCount counter(ENCODING, collect_);
-                    int pic_send_done = (src_file_eos && rec_file_eos) ? 1 : 0;
+                    uint8_t pic_send_done =
+                        (src_file_eos && rec_file_eos) ? 1 : 0;
                     return_error = eb_svt_get_packet(
                         av1enc_ctx_.enc_handle, &enc_out, pic_send_done);
                     ASSERT_NE(return_error, EB_ErrorMax)

--- a/test/e2e_test/SvtAv1E2EParamsTest.cc
+++ b/test/e2e_test/SvtAv1E2EParamsTest.cc
@@ -220,10 +220,12 @@ class CodingOptionTest : public SvtAv1E2ETestFramework {
         }
 
         // verify tile row and tile column
-        uint32_t expect_cols = (video_src_->get_width_with_padding() / 4) /
-                               std::pow(2, config->tile_columns);
-        uint32_t expect_rows = (video_src_->get_height_with_padding() / 4) /
-                               std::pow(2, config->tile_rows);
+        uint32_t expect_cols =
+            (uint32_t)((video_src_->get_width_with_padding() / 4) /
+                       std::pow(2, config->tile_columns));
+        uint32_t expect_rows =
+            (uint32_t)((video_src_->get_height_with_padding() / 4) /
+                       std::pow(2, config->tile_rows));
         printf("expect_cols %d, expect_rows %d\n", expect_cols, expect_rows);
         printf("tile_cols %d, tile_rows %d\n",
                stream_info->tile_cols,

--- a/test/e2e_test/VideoSource.cc
+++ b/test/e2e_test/VideoSource.cc
@@ -11,9 +11,10 @@
  * @author Cidana-Ryan
  *
  ******************************************************************************/
-#include "stdio.h"
+#include <stdio.h>
+#include "EbDefinitions.h"
 #include "VideoSource.h"
-#include "../random.h"
+#include "random.h"
 
 using namespace svt_av1_video_source;
 VideoSource::VideoSource(const VideoColorFormat format, const uint32_t width,
@@ -35,11 +36,12 @@ VideoSource::VideoSource(const VideoColorFormat format, const uint32_t width,
     else
         svt_compressed_2bit_plane_ = false;
     frame_qp_list_.clear();
-};
+}
 
 VideoSource::~VideoSource() {
     deinit_frame_buffer();
-};
+}
+
 bool VideoSource::is_10bit_mode() {
     if (image_format_ == IMG_FMT_420P10_PACKED ||
         image_format_ == IMG_FMT_422P10_PACKED ||
@@ -451,7 +453,7 @@ EbErrorType VideoFileSource::open_source(const uint32_t init_pos,
         return EB_ErrorNone;
     std::string full_path = get_vector_dir() + "/" + file_name_.c_str();
 
-    file_handle_ = fopen(full_path.c_str(), "rb");
+    FOPEN(file_handle_, full_path.c_str(), "rb");
     if (file_handle_ == nullptr) {
         printf(">>> Open video source %s failed!\r\n", full_path.c_str());
         printf(

--- a/test/intrapred_cfl_test.cc
+++ b/test/intrapred_cfl_test.cc
@@ -79,9 +79,11 @@ class CflPredTest {
                 // prepare data
                 for (int y = 0; y < c_h; ++y) {
                     for (int x = 0; x < c_w; ++x) {
-                        pred_buf_q3[y * c_stride + x] = pred_rnd.random();
+                        pred_buf_q3[y * c_stride + x] =
+                            (Sample)pred_rnd.random();
                         dst_buf_ref_[y * c_stride + x] =
-                            dst_buf_tst_[y * c_stride + x] = dst_rnd.random();
+                            dst_buf_tst_[y * c_stride + x] =
+                                (Sample)dst_rnd.random();
                     }
                 }
 

--- a/test/intrapred_dr_test.cc
+++ b/test/intrapred_dr_test.cc
@@ -181,8 +181,8 @@ class DrPredTest {
                 above_data_[i] = left_data_[i] = (1 << bd_) - 1;
         } else {
             for (int i = 0; i < neighbor_buf_size; ++i) {
-                above_data_[i] = rnd.random();
-                left_data_[i] = rnd.random();
+                above_data_[i] = (Sample)rnd.random();
+                left_data_[i] = (Sample)rnd.random();
             }
         }
     }

--- a/test/intrapred_edge_filter_test.cc
+++ b/test/intrapred_edge_filter_test.cc
@@ -73,8 +73,8 @@ class UpsampleTest {
                 // When the process completes, entries -2 to 2*numPx-2
                 // are valid in buf;
                 const int max_idx = (numPx_ - 1) * 2;
-                for (int i = -2; i <= max_idx; ++i)
-                    ASSERT_EQ(edge_ref_[i], edge_tst_[i]);
+                for (int j = -2; j <= max_idx; ++j)
+                    ASSERT_EQ(edge_ref_[j], edge_tst_[j]);
             }
         }
     }
@@ -93,7 +93,7 @@ class UpsampleTest {
         // When the process starts, entries -1 to numPx-1 are valid in buf
         int i = 0;
         for (; i < start_offset + numPx_; ++i)
-            edge_ref_data_[i] = edge_tst_data_[i] = pix_rnd.random();
+            edge_ref_data_[i] = edge_tst_data_[i] = (Sample)pix_rnd.random();
 
         Sample last = edge_ref_data_[start_offset + numPx_ - 1];
         for (; i < edge_buf_size; ++i)
@@ -165,7 +165,7 @@ static void av1_filter_intra_edge_c(uint8_t *p, int sz, int strength) {
             s += edge[k] * kernel[filt][j];
         }
         s = (s + 8) >> 4;
-        p[i] = s;
+        p[i] = (uint8_t)s;
     }
 }
 
@@ -236,7 +236,7 @@ class FilterEdgeTest {
     void prepare_data(SVTRandom &pix_rnd) {
         int i = 0;
         for (; i < start_offset + numPx_; ++i)
-            edge_ref_data_[i] = edge_tst_data_[i] = pix_rnd.random();
+            edge_ref_data_[i] = edge_tst_data_[i] = (Sample)pix_rnd.random();
     }
 
     void run_filter_edge() {

--- a/test/warp_filter_test_util.cc
+++ b/test/warp_filter_test_util.cc
@@ -8,6 +8,14 @@
  * Media Patent License 1.0 was not distributed with this source code in the
  * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
  */
+// workaround to eliminate the compiling warning on linux
+// The macro will conflict with definition in gtest.h
+#ifdef __USE_GNU
+#undef __USE_GNU  // defined in EbThreads.h
+#endif
+#ifdef _GNU_SOURCE
+#undef _GNU_SOURCE  // defined in EbThreads.h
+#endif
 #include "EbDefinitions.h"
 #include "EbUnitTestUtility.h"
 #include "EbWarpedMotion.h"


### PR DESCRIPTION
1. remove all the build warnings in test code on windows, mac and linux.