### PR TITLE
Fix ld warning on osx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ set(flags_to_test
     -Wformat
     -Wformat-security
     -fstack-protector-strong
-    -fPIE
     -fPIC
     -D_FORTIFY_SOURCE=2)
 if(NOT MSVC)


### PR DESCRIPTION
The warning is about linking the shared library with -pie flag,
The warning message is: ld: warning: -pie being ignored.
It is only used when linking a main executable.