### PR TITLE
Fix sad_hme_avx2 func

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -4230,7 +4230,7 @@ void sad_loop_kernel_avx2_hme_l0_intrin(
                     for (k = 0; k < height; k += 2) {
                         ss0 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((__m128i*)pRef)), _mm_loadu_si128((__m128i*)(pRef + ref_stride)), 0x1);
                         ss1 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((__m128i*)(pRef + 8))), _mm_loadu_si128((__m128i*)(pRef + ref_stride + 8)), 0x1);
-                        ss2 = _mm256_load_si256((__m256i*)pSrc);
+                        ss2 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((__m128i*)pSrc)), _mm_loadu_si128((__m128i*)(pSrc + src_stride)), 0x1);
                         ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
                         ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
                         ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010


### PR DESCRIPTION
1.fix variable initialization when block width is 16 and height is not more than 16,which can be verified by SadTest.cc