### PR TITLE
Fix crash issue when speed control flag is enabled;

### DIFF
--- a/Source/Lib/Common/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.c
@@ -421,10 +421,10 @@ EbErrorType picture_control_set_ctor(
     EB_MALLOC_ARRAY(object_ptr->md_rate_estimation_array, 1);
     memset(object_ptr->md_rate_estimation_array, 0, sizeof(MdRateEstimationContext));
 #endif
-    if (initDataPtr->cdf_mode == 0) {
-        EB_MALLOC_ARRAY(object_ptr->ec_ctx_array, all_sb);
-        EB_MALLOC_ARRAY(object_ptr->rate_est_array, all_sb);
-    }
+
+    EB_MALLOC_ARRAY(object_ptr->ec_ctx_array, all_sb);
+    EB_MALLOC_ARRAY(object_ptr->rate_est_array, all_sb);
+
     // Mode Decision Control config
     EB_MALLOC_ARRAY(object_ptr->mdc_sb_array, object_ptr->sb_total_count);
     object_ptr->qp_array_stride = (uint16_t)((initDataPtr->picture_width + MIN_BLOCK_SIZE - 1) / MIN_BLOCK_SIZE);

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -1058,10 +1058,14 @@ void init_nsq_block(
     } while (blk_idx < sequence_control_set_ptr->max_block_cnt);
 }
 void init_sq_non4_block(
+    SequenceControlSet    *sequence_control_set_ptr,
     ModeDecisionContext   *context_ptr){
     for (uint32_t blk_idx = 0; blk_idx < TOTAL_SQ_BLOCK_COUNT; blk_idx++){
         context_ptr->md_cu_arr_nsq[sq_block_index[blk_idx]].part = PARTITION_SPLIT;
         context_ptr->md_local_cu_unit[sq_block_index[blk_idx]].tested_cu_flag = EB_FALSE;
+    }
+    for(uint32_t blk_idx = 0; blk_idx < sequence_control_set_ptr->max_block_cnt; ++blk_idx){
+        context_ptr->md_local_cu_unit[blk_idx].avail_blk_flag = EB_FALSE;
     }
 }
 static INLINE TranHigh check_range(TranHigh input, int32_t bd) {
@@ -5546,6 +5550,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
     }
     else {
         init_sq_non4_block(
+            sequence_control_set_ptr,
             context_ptr);
     }
     // Mode Decision Neighbor Arrays

--- a/Source/Lib/Common/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Common/Codec/EbResourceCoordinationProcess.c
@@ -111,7 +111,7 @@ EbErrorType signal_derivation_pre_analysis_oq(
 
     if (picture_control_set_ptr->enc_mode >= ENC_M8)
         sequence_control_set_ptr->seq_header.enable_restoration = 0;
-
+    sequence_control_set_ptr->cdf_mode = (picture_control_set_ptr->enc_mode <= ENC_M6) ? 0 : 1;
     return return_error;
 }
 


### PR DESCRIPTION
1. update the cdf mode in signal_derivation_pre_analysis_oq;
2. always allocate ec_ctx_array and rate_est_array since cdf_mode might change.
3. initial the avail_blk_flag in init_sq_non4_block.