### PR TITLE
Refine transpose unit test to support more functions.

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/transpose_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/transpose_avx2.c
@@ -8,6 +8,26 @@
 #include "transpose_avx2.h"
 
 void transpose_8bit_16x16_reg128bit_instance_avx2(const __m128i *const in,
-    __m128i *const out) {
-        transpose_8bit_16x16_reg128bit_avx2(in, out);
+                                                  __m128i *const out) {
+  transpose_8bit_16x16_reg128bit_avx2(in, out);
+}
+
+void transpose_32bit_8x8_reg256bit_instance_avx2(const __m256i *const in,
+                                                 __m256i *const out) {
+    transpose_32bit_8x8_avx2(in, out);
+}
+
+void transpose_64bit_4x4_reg256bit_instance_avx2(const __m256i *const in,
+                                                 __m256i *const out) {
+    transpose_64bit_4x4_avx2(in, out);
+}
+
+void transpose_64bit_4x6_reg256bit_instance_avx2(const __m256i *const in,
+                                                 __m256i *const out) {
+    transpose_64bit_4x6_avx2(in, out);
+}
+
+void transpose_64bit_4x8_reg256bit_instance_avx2(const __m256i *const in,
+                                                 __m256i *const out) {
+    transpose_64bit_4x8_avx2(in, out);
 }

--- a/Source/Lib/Common/ASM_AVX2/transpose_avx2.h
+++ b/Source/Lib/Common/ASM_AVX2/transpose_avx2.h
@@ -14,7 +14,19 @@ extern "C" {
 #endif
 
 void transpose_8bit_16x16_reg128bit_instance_avx2(const __m128i *const in,
-    __m128i *const out);
+                                                  __m128i *const out);
+
+void transpose_32bit_8x8_reg256bit_instance_avx2(const __m256i *const in,
+                                                 __m256i *const out);
+
+void transpose_64bit_4x4_reg256bit_instance_avx2(const __m256i *const in,
+                                                 __m256i *const out);
+
+void transpose_64bit_4x6_reg256bit_instance_avx2(const __m256i *const in,
+                                                 __m256i *const out);
+
+void transpose_64bit_4x8_reg256bit_instance_avx2(const __m256i *const in,
+                                                 __m256i *const out);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Common/ASM_SSE2/transpose_sse2.c
+++ b/Source/Lib/Common/ASM_SSE2/transpose_sse2.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+// C instance for unit test.
+
+#include "EbDefinitions.h"
+
+#include "transpose_sse2.h"
+
+void transpose_8bit_4x4_reg128bit_instance_sse2(const __m128i *const in,
+                                                __m128i *const out) {
+    __m128i out_tmp[4] = {0};
+    out_tmp[0] = transpose_8bit_4x4(in);
+    for (size_t i = 0; i < 4; i++) {
+        out[i] = _mm_loadu_si128((__m128i *)(&((uint8_t *)(&out_tmp))[4 * i]));
+    }
+}
+
+void transpose_8bit_8x8_reg128bit_instance_sse2(const __m128i *const in,
+                                                __m128i *const out) {
+    transpose_8bit_8x8(in, out);
+}
+
+void transpose_8bit_16x8_reg128bit_instance_sse2(const __m128i *const in,
+                                                 __m128i *const out) {
+    transpose_8bit_16x8(in, out);
+}
+
+void transpose_8bit_16x16_reg128bit_instance_sse2(const __m128i *const in,
+                                                  __m128i *const out) {
+    transpose_8bit_16x16_sse2(in, out);
+}
+
+void partial_transpose_8bit_8x8_reg128bit_instance_sse2(const __m128i *const in,
+                                                        __m128i *const out) {
+    partial_transpose_8bit_8x8(in, out);
+}
+
+void transpose_16bit_4x4_reg128bit_instance_sse2(const __m128i *const in,
+                                                 __m128i *const out) {
+    transpose_16bit_4x4(in, out);
+}
+
+void transpose_16bit_4x8_reg128bit_instance_sse2(const __m128i *const in,
+                                                 __m128i *const out) {
+    transpose_16bit_4x8(in, out);
+}
+
+void transpose_16bit_8x4_reg128bit_instance_sse2(const __m128i *const in,
+                                                 __m128i *const out) {
+    transpose_16bit_8x4(in, out);
+}
+
+void transpose_16bit_8x8_reg128bit_instance_sse2(const __m128i *const in,
+                                                 __m128i *const out) {
+    transpose_16bit_8x8(in, out);
+}
+
+void transpose_16bit_16x16_reg128bit_instance_sse2(const __m128i *const in,
+                                                   __m128i *const out) {
+    memcpy(out, in, 16 * 16 * sizeof(__m128i));
+    transpose_16bit_16x16(out, &out[16]);
+}
+
+void transpose_32bit_4x4_reg128bit_instance_sse2(const __m128i *const in,
+                                                 __m128i *const out) {
+    transpose_32bit_4x4(in, out);
+}
+
+void transpose_32bit_4x4x2_reg128bit_instance_sse2(const __m128i *const in,
+                                                   __m128i *const out) {
+    transpose_32bit_4x4x2(in, out);
+}
+
+void transpose_32bit_8x4_reg128bit_instance_sse2(const __m128i *const in,
+                                                 __m128i *const out) {
+    transpose_32bit_8x4(in, out);
+}

--- a/Source/Lib/Common/ASM_SSE2/transpose_sse2.h
+++ b/Source/Lib/Common/ASM_SSE2/transpose_sse2.h
@@ -14,7 +14,55 @@
 
 #include <emmintrin.h>  // SSE2
 
- //nclude "./aom_config.h"
+// nclude "./aom_config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void transpose_8bit_4x4_reg128bit_instance_sse2(const __m128i *const in,
+                                                __m128i *const out);
+
+void transpose_8bit_8x8_reg128bit_instance_sse2(const __m128i *const in,
+                                                __m128i *const out);
+
+void transpose_8bit_16x8_reg128bit_instance_sse2(const __m128i *const in,
+                                                 __m128i *const out);
+
+void transpose_8bit_16x16_reg128bit_instance_sse2(const __m128i *const in,
+                                                  __m128i *const out);
+
+void partial_transpose_8bit_8x8_reg128bit_instance_sse2(const __m128i *const in,
+                                                        __m128i *const out);
+
+void transpose_16bit_4x4_reg128bit_instance_sse2(const __m128i *const in,
+                                                 __m128i *const out);
+
+void transpose_16bit_4x8_reg128bit_instance_sse2(const __m128i *const in,
+                                                 __m128i *const out);
+
+void transpose_16bit_8x4_reg128bit_instance_sse2(const __m128i *const in,
+                                                 __m128i *const out);
+
+void transpose_16bit_8x8_reg128bit_instance_sse2(const __m128i *const in,
+                                                 __m128i *const out);
+
+void transpose_16bit_16x16_reg128bit_instance_sse2(const __m128i *const in,
+                                                   __m128i *const out);
+
+void transpose_32bit_4x4_reg128bit_instance_sse2(const __m128i *const in,
+                                                 __m128i *const out);
+
+void transpose_32bit_4x4x2_reg128bit_instance_sse2(const __m128i *const in,
+                                                   __m128i *const out);
+
+void transpose_32bit_8x4_reg128bit_instance_sse2(const __m128i *const in,
+                                                 __m128i *const out);
+
+#ifdef __cplusplus
+}
+#endif
+
 
 static INLINE __m128i transpose_8bit_4x4(const __m128i *const in) {
     // Unpack 16 bit elements. Goes from:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,11 @@ add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING=1)
 
 enable_testing()
 
+if(UNIX)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mavx2")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")
+endif()
+
 file(GLOB all_files
     "*.h"
     "*.c"


### PR DESCRIPTION
support for:
~~~
- transpose_8bit_4x4
- transpose_8bit_8x8
- transpose_8bit_16x8
- transpose_8bit_16x16_sse2
- transpose_8bit_16x16_reg128bit_instance_avx2
- transpose_16bit_4x4
- transpose_16bit_4x8
- transpose_16bit_8x4
- transpose_16bit_8x8
- transpose_16bit_16x16
- transpose_32bit_4x4
- transpose_32bit_4x4x2
- transpose_32bit_8x4
- transpose_32bit_8x8_avx2
- transpose_64bit_4x4_avx2
- transpose_64bit_4x6_avx2
- transpose_64bit_4x8_avx2
~~~