### PR TITLE
Fix mismatch issue in packmsb test

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
@@ -39,7 +39,8 @@ void compressed_packmsb_avx2_intrin(
         //processing 2 lines for chroma
         for (y = 0; y < height; y += 2)
         {
-            in2Bit = _mm_loadu_si128((__m128i*)inn_bit_buffer); //2 Lines Stored in 1D format-Could be replaced by 2 _mm_loadl_epi64
+            //2 Lines Stored in 1D format-Could be replaced by 2 _mm_loadl_epi64
+            in2Bit = _mm_unpacklo_epi64(_mm_loadl_epi64((__m128i*)inn_bit_buffer), _mm_loadl_epi64((__m128i*)(inn_bit_buffer + inn_stride)));
 
             ext0 = _mm_and_si128(in2Bit, msk0);
             ext1 = _mm_and_si128(_mm_slli_epi16(in2Bit, 2), msk0);

--- a/test/PackUnPackTest.cc
+++ b/test/PackUnPackTest.cc
@@ -39,6 +39,7 @@
 #include "EbPictureOperators_AVX2.h"
 #include "EbPackUnPack_SSE2.h"
 #include "EbPackUnPack_C.h"
+#include "EbIntraPrediction.h"
 #include "EbUnitTestUtility.h"
 #include "EbUtility.h"
 #include "random.h"
@@ -174,9 +175,9 @@ class PackMsbTest : public ::testing::Test,
     PackMsbTest()
         : area_width_(std::get<0>(GetParam())),
           area_height_(std::get<1>(GetParam())) {
-        in8_stride_ = out_stride_ = MAX_SB_SIZE;
+        in8_stride_ = out_stride_ = MAX_PU_SIZE;
         inn_stride = in8_stride_ >> 2;
-        test_size_ = MAX_SB_SQUARE;
+        test_size_ = MAX_PU_SIZE * MAX_PU_SIZE;
         inn_bit_buffer_ = nullptr;
         in_8bit_buffer_ = nullptr;
         out_16bit_buffer1_ = nullptr;
@@ -185,7 +186,7 @@ class PackMsbTest : public ::testing::Test,
 
     void SetUp() override {
         inn_bit_buffer_ =
-            reinterpret_cast<uint8_t *>(eb_aom_memalign(32, test_size_ >> 2));
+            reinterpret_cast<uint8_t *>(eb_aom_memalign(32, test_size_ >> 4));
         in_8bit_buffer_ =
             reinterpret_cast<uint8_t *>(eb_aom_memalign(32, test_size_));
         out_16bit_buffer1_ = reinterpret_cast<uint16_t *>(
@@ -226,7 +227,7 @@ class PackMsbTest : public ::testing::Test,
 
     void run_test() {
         for (int i = 0; i < RANDOM_TIME; i++) {
-            eb_buf_random_u8(inn_bit_buffer_, test_size_ >> 2);
+            eb_buf_random_u8(inn_bit_buffer_, test_size_ >> 4);
             eb_buf_random_u8(in_8bit_buffer_, test_size_);
             compressed_packmsb_avx2_intrin(in_8bit_buffer_,
                                            in8_stride_,


### PR DESCRIPTION
1. load two line data with repect of in_stride
2. reduce the stride depend on the implementation of
   compressed_packmsb_avx2_intrin