### PR TITLE
Fix build issue in DeblockTest

### DIFF
--- a/test/MotionEstimationTest.cc
+++ b/test/MotionEstimationTest.cc
@@ -15,7 +15,6 @@
 #include "EbUnitTest.h"
 #include "EbUnitTestUtility.h"
 
-static const int num_test = 28;
 static const int num_sad = 22;
 
 struct DistInfo {

--- a/test/TemporalFilterTest.cc
+++ b/test/TemporalFilterTest.cc
@@ -25,16 +25,14 @@
 
 extern "C" {
 #include "EbTemporalFiltering_sse4.h"
-void apply_filtering_c(const uint8_t *y_src, int y_src_stride,
-                       const uint8_t *y_pre, int y_pre_stride,
-                       const uint8_t *u_src, const uint8_t *v_src,
-                       int uv_src_stride, const uint8_t *u_pre,
-                       const uint8_t *v_pre, int uv_pre_stride,
-                       unsigned int block_width, unsigned int block_height,
-                       int ss_x, int ss_y, int strength, const int *blk_fw,
-                       int use_whole_blk, uint32_t *y_accum, uint16_t *y_count,
-                       uint32_t *u_accum, uint16_t *u_count, uint32_t *v_accum,
-                       uint16_t *v_count);
+void svt_av1_apply_filtering_c(
+    const uint8_t *y_src, int y_src_stride, const uint8_t *y_pre,
+    int y_pre_stride, const uint8_t *u_src, const uint8_t *v_src,
+    int uv_src_stride, const uint8_t *u_pre, const uint8_t *v_pre,
+    int uv_pre_stride, unsigned int block_width, unsigned int block_height,
+    int ss_x, int ss_y, int strength, const int *blk_fw, int use_whole_blk,
+    uint32_t *y_accum, uint16_t *y_count, uint32_t *u_accum, uint16_t *u_count,
+    uint32_t *v_accum, uint16_t *v_count);
 }
 
 using svt_av1_test_tool::SVTRandom;  // to generate the random
@@ -50,7 +48,7 @@ BlockIndex TEST_BLOCK[] = {
 static const uint32_t index_16x16_from_subindexes[4][4] = {
     {0, 1, 4, 5}, {2, 3, 6, 7}, {8, 9, 12, 13}, {10, 11, 14, 15}};
 
-const int stride_pred_[COLOR_CHANNELS] = {BW, BW_CH, BW_CH};
+const int stride_pred_[COLOR_CHANNELS] = {BW, BW >> 1, BW >> 1};
 const int ALTREF_STRENGTH[] = {0, 1, 2, 3, 4, 5, 6};
 
 typedef std::tuple<BlockIndex, FilterWeightPattern, int> TestParam;
@@ -258,52 +256,52 @@ class TemporalFilterTest : public ::testing::Test,
             }
             prepare_data();
             init_param();
-            apply_filtering_c(src_ptr_[C_Y],
-                              stride_[C_Y],
-                              pred_ptr_[C_Y],
-                              stride_pred_[C_Y],
-                              src_ptr_[C_U],
-                              src_ptr_[C_V],
-                              stride_[C_U],
-                              pred_ptr_[C_U],
-                              pred_ptr_[C_V],
-                              stride_pred_[C_U],
-                              block_width_,
-                              block_height_,
-                              ss_x_,
-                              ss_y_,
-                              altref_strength_,
-                              blk_fw_32x32_,
-                              0,  // use_32x32
-                              accum_ptr1_[C_Y],
-                              count_ptr1_[C_Y],
-                              accum_ptr1_[C_U],
-                              count_ptr1_[C_U],
-                              accum_ptr1_[C_V],
-                              count_ptr1_[C_V]);
-            av1_apply_temporal_filter_sse4_1(src_ptr_[C_Y],
-                                             stride_[C_Y],
-                                             pred_ptr_[C_Y],
-                                             stride_pred_[C_Y],
-                                             src_ptr_[C_U],
-                                             src_ptr_[C_V],
-                                             stride_[C_U],
-                                             pred_ptr_[C_U],
-                                             pred_ptr_[C_V],
-                                             stride_pred_[C_U],
-                                             block_width_,
-                                             block_height_,
-                                             ss_x_,
-                                             ss_y_,
-                                             altref_strength_,
-                                             blk_fw_32x32_,
-                                             0,  // use_32x32
-                                             accum_ptr2_[C_Y],
-                                             count_ptr2_[C_Y],
-                                             accum_ptr2_[C_U],
-                                             count_ptr2_[C_U],
-                                             accum_ptr2_[C_V],
-                                             count_ptr2_[C_V]);
+            svt_av1_apply_filtering_c(src_ptr_[C_Y],
+                                      stride_[C_Y],
+                                      pred_ptr_[C_Y],
+                                      stride_pred_[C_Y],
+                                      src_ptr_[C_U],
+                                      src_ptr_[C_V],
+                                      stride_[C_U],
+                                      pred_ptr_[C_U],
+                                      pred_ptr_[C_V],
+                                      stride_pred_[C_U],
+                                      block_width_,
+                                      block_height_,
+                                      ss_x_,
+                                      ss_y_,
+                                      altref_strength_,
+                                      blk_fw_32x32_,
+                                      0,  // use_32x32
+                                      accum_ptr1_[C_Y],
+                                      count_ptr1_[C_Y],
+                                      accum_ptr1_[C_U],
+                                      count_ptr1_[C_U],
+                                      accum_ptr1_[C_V],
+                                      count_ptr1_[C_V]);
+            svt_av1_apply_temporal_filter_sse4_1(src_ptr_[C_Y],
+                                                 stride_[C_Y],
+                                                 pred_ptr_[C_Y],
+                                                 stride_pred_[C_Y],
+                                                 src_ptr_[C_U],
+                                                 src_ptr_[C_V],
+                                                 stride_[C_U],
+                                                 pred_ptr_[C_U],
+                                                 pred_ptr_[C_V],
+                                                 stride_pred_[C_U],
+                                                 block_width_,
+                                                 block_height_,
+                                                 ss_x_,
+                                                 ss_y_,
+                                                 altref_strength_,
+                                                 blk_fw_32x32_,
+                                                 0,  // use_32x32
+                                                 accum_ptr2_[C_Y],
+                                                 count_ptr2_[C_Y],
+                                                 accum_ptr2_[C_U],
+                                                 count_ptr2_[C_U],
+                                                 accum_ptr2_[C_V],
+                                                 count_ptr2_[C_V]);
 
             check_accum_output();
             check_count_output();

--- a/test/loopfilter_ref.h
+++ b/test/loopfilter_ref.h
@@ -432,22 +432,6 @@ static INLINE void highbd_filter14(int8_t mask, uint8_t thresh, int8_t flat,
     }
 }
 
-static void aom_lpf_vertical_6_c(uint8_t *s, int pitch, const uint8_t *blimit,
-                                 const uint8_t *limit, const uint8_t *thresh) {
-    int i;
-    int count = 4;
-
-    for (i = 0; i < count; ++i) {
-        const uint8_t p2 = s[-3], p1 = s[-2], p0 = s[-1];
-        const uint8_t q0 = s[0], q1 = s[1], q2 = s[2];
-        const int8_t mask =
-            filter_mask3_chroma(*limit, *blimit, p2, p1, p0, q0, q1, q2);
-        const int8_t flat = flat_mask3_chroma(1, p2, p1, p0, q0, q1, q2);
-        filter6(mask, *thresh, flat, s - 3, s - 2, s - 1, s, s + 1, s + 2);
-        s += pitch;
-    }
-}
-
 static void aom_highbd_lpf_horizontal_6_c(uint16_t *s, int p,
                                           const uint8_t *blimit,
                                           const uint8_t *limit,


### PR DESCRIPTION
1) Removed reference function "aom_lpf_vertical_6_c" in loopfilter_ref.h
to avoid build issue:

test/loopfilter_ref.h:436:77: error: ‘void aom_lpf_vertical_6_c(uint8_t*, int, const uint8_t*, const uint8_t*, const uint8_t*)’ was declared ‘extern’ and later ‘static’ [-fpermissive]
    const uint8_t *limit, const uint8_t *thresh) {
In file included from /test/DeblockTest.cc:35:0:
/Source/Lib/Common/Codec/EbDeblockingFilter.h:226:10: note: previous declaration of ‘void aom_lpf_vertical_6_c(uint8_t*, int32_t, const uint8_t*, const uint8_t*, const uint8_t*)’
    void aom_lpf_vertical_6_c(uint8_t *s, int32_t pitch, const uint8_t *blimit, const uint8_t *limit, const uint8_t *thresh);          ^

2) Removed "static const int num_test = 28;"

3) Replaced "BW_CH" with "BW >> 1" for it was deleted.

4) Fiexed build issue for some functions being renamed.