### PR TITLE
refine unit test in github ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: sudo apt-get install -y nasm yasm cmake gcc-9 g++-9
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 1
       - name: Compile SVT-AV1 (Release, Tests)
@@ -147,7 +147,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: sudo apt-get install -y nasm yasm cmake gcc-9 g++-9
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 1
       - name: Compile SVT-AV1 (Release, Tests and TestVectors)
@@ -157,4 +157,4 @@ jobs:
           make TestVectors
           popd
       - name: Run unit tests shard
-        run: env SVT_AV1_TEST_VECTOR_PATH="./test/vectors" GTEST_TOTAL_SHARDS=8 GTEST_SHARD_INDEX=${{ matrix.index }} ./Bin/Release/SvtAv1E2ETests
+        run: env SVT_AV1_TEST_VECTOR_PATH="./test/vectors" GTEST_TOTAL_SHARDS=8 GTEST_SHARD_INDEX=${{ matrix.index }} ./Bin/Release/SvtAv1E2ETests --gtest_filter=-*DummySrcTest*


### PR DESCRIPTION
1. change check flow from actions/checkout@v1 to actions/checkout@v2
 - to resolve issue of GitHub CI action can not checkout source code sometimes, 
2. disabled DummySrcTest to avoid out of memory in GitHub CI test machine
 - to resolve the out-of-memory issue (signal 9) happened in PRs:
[1063](https://github.com/OpenVisualCloud/SVT-AV1/runs/459759523)
[1066](https://github.com/OpenVisualCloud/SVT-AV1/runs/461281875)
[1071](https://github.com/OpenVisualCloud/SVT-AV1/runs/463515577)