### PR TITLE
Fix bug in PackMsbTest

### DIFF
--- a/test/PackUnPackTest.cc
+++ b/test/PackUnPackTest.cc
@@ -59,8 +59,7 @@ AreaSize TEST_PACK_SIZES[] = {AreaSize(32, 32),
                               AreaSize(32, 64)};
 
 // test c_pack_avx2_intrin, which only support width of 32 and 64;
-class PackTest : public ::testing::Test,
-                 public ::testing::WithParamInterface<AreaSize> {
+class PackTest : public ::testing::TestWithParam<AreaSize> {
   public:
     PackTest()
         : area_width_(std::get<0>(GetParam())),
@@ -86,14 +85,10 @@ class PackTest : public ::testing::Test,
             reinterpret_cast<uint8_t *>(eb_aom_memalign(32, test_size_));
         local_cache2_ =
             reinterpret_cast<uint8_t *>(eb_aom_memalign(32, test_size_));
-        memset(in_compn_bit_buffer1_,
-               0,
-               test_size_ * sizeof(in_compn_bit_buffer1_[0]));
-        memset(in_compn_bit_buffer2_,
-               0,
-               test_size_ * sizeof(in_compn_bit_buffer2_[0]));
-        memset(local_cache1_, 0, test_size_ * sizeof(local_cache1_[0]));
-        memset(local_cache2_, 0, test_size_ * sizeof(local_cache2_[0]));
+        memset(in_compn_bit_buffer1_, 0, test_size_);
+        memset(in_compn_bit_buffer2_, 0, test_size_);
+        memset(local_cache1_, 0, test_size_);
+        memset(local_cache2_, 0, test_size_);
     }
 
     void TearDown() override {
@@ -107,6 +102,7 @@ class PackTest : public ::testing::Test,
             eb_aom_free(local_cache1_);
         if (local_cache2_)
             eb_aom_free(local_cache2_);
+        aom_clear_system_state();
     }
 
   protected:
@@ -170,14 +166,13 @@ INSTANTIATE_TEST_CASE_P(PACK, PackTest, ::testing::ValuesIn(TEST_PACK_SIZES));
 // test compressed_packmsb_avx2_intrin
 // only width of 32 and 64 are supported in compressed_packmsb_avx2_intrin.
 // Use TEST_PACK_SIZES to test.
-class PackMsbTest : public ::testing::Test,
-                    public ::testing::WithParamInterface<AreaSize> {
+class PackMsbTest : public ::testing::TestWithParam<AreaSize> {
   public:
     PackMsbTest()
         : area_width_(std::get<0>(GetParam())),
           area_height_(std::get<1>(GetParam())) {
         in8_stride_ = out_stride_ = MAX_PU_SIZE;
-        inn_stride = in8_stride_ >> 2;
+        inn_stride_ = in8_stride_ >> 2;
         test_size_ = MAX_PU_SIZE * MAX_PU_SIZE;
         inn_bit_buffer_ = nullptr;
         in_8bit_buffer_ = nullptr;
@@ -194,10 +189,8 @@ class PackMsbTest : public ::testing::Test,
             eb_aom_memalign(32, sizeof(uint16_t) * test_size_));
         out_16bit_buffer2_ = reinterpret_cast<uint16_t *>(
             eb_aom_memalign(32, sizeof(uint16_t) * test_size_));
-        memset(
-            out_16bit_buffer1_, 0, test_size_ * sizeof(out_16bit_buffer1_[0]));
-        memset(
-            out_16bit_buffer2_, 0, test_size_ * sizeof(out_16bit_buffer2_[0]));
+        memset(out_16bit_buffer1_, 0, sizeof(uint16_t) * test_size_);
+        memset(out_16bit_buffer2_, 0, sizeof(uint16_t) * test_size_);
     }
 
     void TearDown() override {
@@ -209,6 +202,7 @@ class PackMsbTest : public ::testing::Test,
             eb_aom_free(out_16bit_buffer1_);
         if (out_16bit_buffer2_)
             eb_aom_free(out_16bit_buffer2_);
+        aom_clear_system_state();
     }
 
   protected:
@@ -234,19 +228,19 @@ class PackMsbTest : public ::testing::Test,
                                            in8_stride_,
                                            inn_bit_buffer_,
                                            out_16bit_buffer1_,
-                                           inn_stride,
+                                           inn_stride_,
                                            out_stride_,
                                            area_width_,
                                            area_height_);
 
             compressed_packmsb_c(in_8bit_buffer_,
-                               in8_stride_,
-                               inn_bit_buffer_,
-                               out_16bit_buffer2_,
-                               inn_stride,
-                               out_stride_,
-                               area_width_,
-                               area_height_);
+                                 in8_stride_,
+                                 inn_bit_buffer_,
+                                 out_16bit_buffer2_,
+                                 inn_stride_,
+                                 out_stride_,
+                                 area_width_,
+                                 area_height_);
 
             check_output(area_width_,
                          area_height_,
@@ -261,7 +255,7 @@ class PackMsbTest : public ::testing::Test,
     }
 
     uint8_t *inn_bit_buffer_, *in_8bit_buffer_;
-    uint32_t in8_stride_, inn_stride, out_stride_;
+    uint32_t in8_stride_, inn_stride_, out_stride_;
     uint16_t *out_16bit_buffer1_, *out_16bit_buffer2_;
     uint32_t area_width_, area_height_;
     uint32_t test_size_;
@@ -287,8 +281,7 @@ AreaSize TEST_COMMON_SIZES[] = {
     AreaSize(68, 64),  AreaSize(72, 64), AreaSize(80, 64), AreaSize(96, 64),
     AreaSize(64, 128), AreaSize(128, 64)};
 
-class Pack2dTest : public ::testing::Test,
-                   public ::testing::WithParamInterface<AreaSize> {
+class Pack2dTest : public ::testing::TestWithParam<AreaSize> {
   public:
     Pack2dTest()
         : area_width_(std::get<0>(GetParam())),
@@ -297,9 +290,9 @@ class Pack2dTest : public ::testing::Test,
         test_size_ = MAX_SB_SQUARE;
         in_8bit_buffer_ = nullptr;
         inn_bit_buffer_ = nullptr;
-        out_16bit_buffer1_ = nullptr;
+        out_16bit_buffer_avx2_ = nullptr;
         out_16bit_buffer_c_ = nullptr;
-        out_16bit_buffer3_ = nullptr;
+        out_16bit_buffer_sse2_ = nullptr;
     }
 
     void SetUp() override {
@@ -307,19 +300,15 @@ class Pack2dTest : public ::testing::Test,
             reinterpret_cast<uint8_t *>(eb_aom_memalign(32, test_size_));
         inn_bit_buffer_ =
             reinterpret_cast<uint8_t *>(eb_aom_memalign(32, test_size_));
-        out_16bit_buffer1_ = reinterpret_cast<uint16_t *>(
+        out_16bit_buffer_avx2_ = reinterpret_cast<uint16_t *>(
             eb_aom_memalign(32, sizeof(uint16_t) * test_size_));
         out_16bit_buffer_c_ = reinterpret_cast<uint16_t *>(
             eb_aom_memalign(32, sizeof(uint16_t) * test_size_));
-        out_16bit_buffer3_ = reinterpret_cast<uint16_t *>(
+        out_16bit_buffer_sse2_ = reinterpret_cast<uint16_t *>(
             eb_aom_memalign(32, sizeof(uint16_t) * test_size_));
-        memset(
-            out_16bit_buffer1_, 0, test_size_ * sizeof(out_16bit_buffer1_[0]));
-        memset(out_16bit_buffer_c_,
-               0,
-               test_size_ * sizeof(out_16bit_buffer_c_[0]));
-        memset(
-            out_16bit_buffer3_, 0, test_size_ * sizeof(out_16bit_buffer3_[0]));
+        memset(out_16bit_buffer_avx2_, 0, sizeof(uint16_t) * test_size_);
+        memset(out_16bit_buffer_c_, 0, sizeof(uint16_t) * test_size_);
+        memset(out_16bit_buffer_sse2_, 0, sizeof(uint16_t) * test_size_);
     }
 
     void TearDown() override {
@@ -327,12 +316,13 @@ class Pack2dTest : public ::testing::Test,
             eb_aom_free(in_8bit_buffer_);
         if (inn_bit_buffer_)
             eb_aom_free(inn_bit_buffer_);
-        if (out_16bit_buffer1_)
-            eb_aom_free(out_16bit_buffer1_);
+        if (out_16bit_buffer_avx2_)
+            eb_aom_free(out_16bit_buffer_avx2_);
         if (out_16bit_buffer_c_)
             eb_aom_free(out_16bit_buffer_c_);
-        if (out_16bit_buffer3_)
-            eb_aom_free(out_16bit_buffer3_);
+        if (out_16bit_buffer_sse2_)
+            eb_aom_free(out_16bit_buffer_sse2_);
+        aom_clear_system_state();
     }
 
   protected:
@@ -358,7 +348,7 @@ class Pack2dTest : public ::testing::Test,
             eb_enc_msb_pack2d_avx2_intrin_al(in_8bit_buffer_,
                                              in_stride_,
                                              inn_bit_buffer_,
-                                             out_16bit_buffer1_,
+                                             out_16bit_buffer_avx2_,
                                              out_stride_,
                                              out_stride_,
                                              area_width_,
@@ -374,7 +364,7 @@ class Pack2dTest : public ::testing::Test,
             eb_enc_msb_pack2d_sse2_intrin(in_8bit_buffer_,
                                           in_stride_,
                                           inn_bit_buffer_,
-                                          out_16bit_buffer3_,
+                                          out_16bit_buffer_sse2_,
                                           out_stride_,
                                           out_stride_,
                                           area_width_,
@@ -382,11 +372,11 @@ class Pack2dTest : public ::testing::Test,
 
             check_output(area_width_,
                          area_height_,
-                         out_16bit_buffer1_,
+                         out_16bit_buffer_avx2_,
                          out_16bit_buffer_c_);
             check_output(area_width_,
                          area_height_,
-                         out_16bit_buffer3_,
+                         out_16bit_buffer_sse2_,
                          out_16bit_buffer_c_);
 
             EXPECT_FALSE(HasFailure())
@@ -398,7 +388,8 @@ class Pack2dTest : public ::testing::Test,
 
     uint8_t *in_8bit_buffer_, *inn_bit_buffer_;
     uint32_t in_stride_, out_stride_;
-    uint16_t *out_16bit_buffer1_, *out_16bit_buffer_c_, *out_16bit_buffer3_;
+    uint16_t *out_16bit_buffer_avx2_, *out_16bit_buffer_c_,
+        *out_16bit_buffer_sse2_;
     uint32_t area_width_, area_height_;
     uint32_t test_size_;
 };
@@ -413,8 +404,7 @@ INSTANTIATE_TEST_CASE_P(PACK2D, Pack2dTest,
 // test eb_enc_un_pack8_bit_data_avx2_intrin
 // Similar assumption that the width is multiple of 4, using
 // TEST_COMMON_SIZES to cover all the special width.
-class UnPackTest : public ::testing::Test,
-                   public ::testing::WithParamInterface<AreaSize> {
+class UnPackTest : public ::testing::TestWithParam<AreaSize> {
   public:
     UnPackTest()
         : area_width_(std::get<0>(GetParam())),
@@ -439,10 +429,10 @@ class UnPackTest : public ::testing::Test,
             reinterpret_cast<uint8_t *>(eb_aom_memalign(32, test_size_));
         in_16bit_buffer_ = reinterpret_cast<uint16_t *>(
             eb_aom_memalign(32, sizeof(uint16_t) * test_size_));
-        memset(out_8bit_buffer1_, 0, test_size_ * sizeof(out_8bit_buffer1_[0]));
-        memset(out_8bit_buffer2_, 0, test_size_ * sizeof(out_8bit_buffer2_[0]));
-        memset(out_nbit_buffer1_, 0, test_size_ * sizeof(out_8bit_buffer1_[0]));
-        memset(out_nbit_buffer2_, 0, test_size_ * sizeof(out_8bit_buffer2_[0]));
+        memset(out_8bit_buffer1_, 0, test_size_);
+        memset(out_8bit_buffer2_, 0, test_size_);
+        memset(out_nbit_buffer1_, 0, test_size_);
+        memset(out_nbit_buffer2_, 0, test_size_);
     }
 
     void TearDown() override {
@@ -456,6 +446,7 @@ class UnPackTest : public ::testing::Test,
             eb_aom_free(out_nbit_buffer1_);
         if (out_nbit_buffer2_)
             eb_aom_free(out_nbit_buffer2_);
+        aom_clear_system_state();
     }
 
   protected:
@@ -483,11 +474,11 @@ class UnPackTest : public ::testing::Test,
                                                  area_width_,
                                                  area_height_);
             un_pack8_bit_data_c(in_16bit_buffer_,
-                              in_stride_,
-                              out_8bit_buffer2_,
-                              out_stride_,
-                              area_width_,
-                              area_height_);
+                                in_stride_,
+                                out_8bit_buffer2_,
+                                out_stride_,
+                                area_width_,
+                                area_height_);
 
             check_output(area_width_,
                          area_height_,
@@ -580,38 +571,36 @@ AreaSize TEST_AVG_SIZES[] = {AreaSize(4, 4),
                              AreaSize(64, 32),
                              AreaSize(32, 64)};
 
-class UnPackAvgTest : public ::testing::Test,
-                      public ::testing::WithParamInterface<AreaSize> {
+class UnPackAvgTest : public ::testing::TestWithParam<AreaSize> {
   public:
     UnPackAvgTest()
         : area_width_(std::get<0>(GetParam())),
           area_height_(std::get<1>(GetParam())) {
         in_stride_ = out_stride_ = MAX_SB_SIZE;
         test_size_ = MAX_SB_SQUARE;
-        out_8bit_buffer1_ = nullptr;
+        out_8bit_buffer_avx2_ = nullptr;
         out_8bit_buffer_c_ = nullptr;
-        out_8bit_buffer3_ = nullptr;
+        out_8bit_buffer_sse2_ = nullptr;
         in_16bit_buffer1_ = nullptr;
         in_16bit_buffer2_ = nullptr;
     }
 
     void SetUp() override {
-        out_8bit_buffer1_ =
+        out_8bit_buffer_avx2_ =
             reinterpret_cast<uint8_t *>(eb_aom_memalign(32, test_size_));
         out_8bit_buffer_c_ =
             reinterpret_cast<uint8_t *>(eb_aom_memalign(32, test_size_));
-        out_8bit_buffer3_ =
+        out_8bit_buffer_sse2_ =
             reinterpret_cast<uint8_t *>(eb_aom_memalign(32, test_size_));
         in_16bit_buffer1_ = reinterpret_cast<uint16_t *>(
             eb_aom_memalign(32, sizeof(uint16_t) * test_size_));
         in_16bit_buffer2_ = reinterpret_cast<uint16_t *>(
             eb_aom_memalign(32, sizeof(uint16_t) * test_size_));
-        memset(in_16bit_buffer1_, 0, test_size_ * sizeof(in_16bit_buffer1_[0]));
-        memset(in_16bit_buffer2_, 0, test_size_ * sizeof(in_16bit_buffer2_[0]));
-        memset(out_8bit_buffer1_, 0, test_size_ * sizeof(out_8bit_buffer1_[0]));
-        memset(
-            out_8bit_buffer_c_, 0, test_size_ * sizeof(out_8bit_buffer_c_[0]));
-        memset(out_8bit_buffer3_, 0, test_size_ * sizeof(out_8bit_buffer3_[0]));
+        memset(in_16bit_buffer1_, 0, sizeof(uint16_t) * test_size_);
+        memset(in_16bit_buffer2_, 0, sizeof(uint16_t) * test_size_);
+        memset(out_8bit_buffer_avx2_, 0, test_size_);
+        memset(out_8bit_buffer_c_, 0, test_size_);
+        memset(out_8bit_buffer_sse2_, 0, test_size_);
     }
 
     void TearDown() override {
@@ -619,12 +608,13 @@ class UnPackAvgTest : public ::testing::Test,
             eb_aom_free(in_16bit_buffer1_);
         if (in_16bit_buffer2_)
             eb_aom_free(in_16bit_buffer2_);
-        if (out_8bit_buffer1_)
-            eb_aom_free(out_8bit_buffer1_);
+        if (out_8bit_buffer_avx2_)
+            eb_aom_free(out_8bit_buffer_avx2_);
         if (out_8bit_buffer_c_)
             eb_aom_free(out_8bit_buffer_c_);
-        if (out_8bit_buffer3_)
-            eb_aom_free(out_8bit_buffer3_);
+        if (out_8bit_buffer_sse2_)
+            eb_aom_free(out_8bit_buffer_sse2_);
+        aom_clear_system_state();
     }
 
   protected:
@@ -659,33 +649,33 @@ class UnPackAvgTest : public ::testing::Test,
                                    in_stride_,
                                    in_16bit_buffer2_,
                                    in_stride_,
-                                   out_8bit_buffer1_,
+                                   out_8bit_buffer_avx2_,
                                    out_stride_,
                                    area_width_,
                                    area_height_);
             unpack_avg_c(in_16bit_buffer1_,
-                       in_stride_,
-                       in_16bit_buffer2_,
-                       in_stride_,
-                       out_8bit_buffer_c_,
-                       out_stride_,
-                       area_width_,
-                       area_height_);
+                         in_stride_,
+                         in_16bit_buffer2_,
+                         in_stride_,
+                         out_8bit_buffer_c_,
+                         out_stride_,
+                         area_width_,
+                         area_height_);
             unpack_avg_sse2_intrin(in_16bit_buffer1_,
                                    in_stride_,
                                    in_16bit_buffer2_,
                                    in_stride_,
-                                   out_8bit_buffer3_,
+                                   out_8bit_buffer_sse2_,
                                    out_stride_,
                                    area_width_,
                                    area_height_);
             check_output(area_width_,
                          area_height_,
-                         out_8bit_buffer1_,
+                         out_8bit_buffer_avx2_,
                          out_8bit_buffer_c_);
             check_output(area_width_,
                          area_height_,
-                         out_8bit_buffer3_,
+                         out_8bit_buffer_sse2_,
                          out_8bit_buffer_c_);
 
             EXPECT_FALSE(HasFailure())
@@ -703,24 +693,24 @@ class UnPackAvgTest : public ::testing::Test,
                                                 in_stride_,
                                                 in_16bit_buffer2_,
                                                 in_stride_,
-                                                out_8bit_buffer1_,
+                                                out_8bit_buffer_avx2_,
                                                 out_stride_,
                                                 false,
                                                 area_width_,
                                                 area_height_);
                 unpack_avg_safe_sub_c(in_16bit_buffer1_,
-                                    in_stride_,
-                                    in_16bit_buffer2_,
-                                    in_stride_,
-                                    out_8bit_buffer_c_,
-                                    out_stride_,
-                                    false,
-                                    area_width_,
-                                    area_height_);
+                                      in_stride_,
+                                      in_16bit_buffer2_,
+                                      in_stride_,
+                                      out_8bit_buffer_c_,
+                                      out_stride_,
+                                      false,
+                                      area_width_,
+                                      area_height_);
 
                 check_output(area_width_,
                              area_height_,
-                             out_8bit_buffer1_,
+                             out_8bit_buffer_avx2_,
                              out_8bit_buffer_c_);
 
                 EXPECT_FALSE(HasFailure())
@@ -733,7 +723,7 @@ class UnPackAvgTest : public ::testing::Test,
 
     uint16_t *in_16bit_buffer1_, *in_16bit_buffer2_;
     uint32_t in_stride_, out_stride_;
-    uint8_t *out_8bit_buffer1_, *out_8bit_buffer_c_, *out_8bit_buffer3_;
+    uint8_t *out_8bit_buffer_avx2_, *out_8bit_buffer_c_, *out_8bit_buffer_sse2_;
     uint32_t area_width_, area_height_;
     uint32_t test_size_;
 };


### PR DESCRIPTION
1. fix the allocate size of inn_bit_buffer_, issue of reading across the bound:
~~~
[----------] 1 test from PACKMSB/PackMsbTest
[ RUN      ] PACKMSB/PackMsbTest.PackMsbTest/5
unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
[  FAILED  ] PACKMSB/PackMsbTest.PackMsbTest/5, where GetParam() = (64, 32) (1 ms)
[----------] 1 test from PACKMSB/PackMsbTest (1 ms total)
~~~
2. clean-up code to make easier to read