### PR TITLE
remove const variable redefinition

### DIFF
--- a/Source/Lib/Encoder/Codec/EbFullLoop.c
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.c
@@ -2404,7 +2404,7 @@ void encode_pass_tx_search(PictureControlSet *pcs_ptr, EncDecContext *context_pt
         candidate_buffer->candidate_ptr->type              = blk_ptr->prediction_mode_flag;
         candidate_buffer->candidate_ptr->pred_mode         = blk_ptr->pred_mode;
         candidate_buffer->candidate_ptr->filter_intra_mode = blk_ptr->filter_intra_mode;
-        const uint32_t coeff1d_offset                      = context_ptr->coded_area_sb;
+        //const uint32_t coeff1d_offset                      = context_ptr->coded_area_sb;
 
         av1_txb_estimate_coeff_bits(
             context_ptr->md_context,


### PR DESCRIPTION
coeff1d_offset is defined twice in function encode_pass_tx_search, the second define within for loop will overwrite the coeff1d_offset outside the for loop.